### PR TITLE
fix(worker-runtime): do not set headers on remix responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3052,6 +3052,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@remix-pwa/client": {
+      "resolved": "packages/client",
+      "link": true
+    },
     "node_modules/@remix-pwa/dev": {
       "resolved": "packages/dev",
       "link": true
@@ -20997,6 +21001,13 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/client": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "packages/dev": {

--- a/packages/dev/compiler/utils/__test__/config.test.ts
+++ b/packages/dev/compiler/utils/__test__/config.test.ts
@@ -3,6 +3,17 @@ import { ServerMode } from '@remix-run/dev/dist/config/serverModes.js';
 import { afterAll, afterEach, describe, expect, test, vi } from 'vitest';
 
 const REMIX_ROOT = '.';
+const mockResolve = vi.hoisted(() => vi.fn());
+const mockRelative = vi.hoisted(() => vi.fn());
+const mockExists = vi.hoisted(() => vi.fn());
+
+vi.doMock('node:path', () => ({
+  resolve: mockResolve,
+  relative: mockRelative,
+}));
+vi.doMock('node:fs', () => ({
+  existsSync: mockExists,
+}));
 vi.doMock('@remix-run/dev/dist/config.js', () => {
   return {
     readConfig: () =>
@@ -27,9 +38,14 @@ describe('readConfig', () => {
   afterAll(() => {
     vi.doUnmock('@remix-run/dev/dist/config');
     vi.doUnmock('./remix.config.ts');
+    vi.doUnmock('node:fs');
+    vi.doUnmock('node:path');
   });
 
   test('should return the resolved config object with default worker options', async () => {
+    mockExists.mockReturnValue(false);
+    mockResolve.mockReturnValue('/public');
+
     vi.doMock('./remix.config.ts', () => {
       return { default: {} };
     });
@@ -44,7 +60,7 @@ describe('readConfig', () => {
       ignoredRouteFiles: ['**/.*'],
       serverModuleFormat: 'cjs',
       serverPlatform: 'node',
-      worker: expect.stringContaining('service-worker.internal.js'),
+      worker: 'service-worker.internal.js',
       workerBuildDirectory: expect.stringContaining('public'),
       workerMinify: false,
       workerName: 'entry.worker',
@@ -52,7 +68,24 @@ describe('readConfig', () => {
     });
   });
 
+  test('should find the user entry file', async () => {
+    mockResolve.mockReturnValue('mock.entry.worker.js');
+    mockRelative.mockReturnValue('relative-path/mock.entry.worker.js');
+    mockExists.mockReturnValue(true);
+
+    vi.doMock('./remix.config.ts', () => {
+      return { default: {} };
+    });
+
+    const { default: readConfig } = await import('../config.js');
+    const config = await readConfig(REMIX_ROOT, ServerMode.Test);
+
+    expect(config).toHaveProperty('entryWorkerFile', 'relative-path/mock.entry.worker.js');
+  });
+
   test('should return the resolved config object with custom worker options', async () => {
+    mockExists.mockReturnValue(false);
+
     vi.doMock('./remix.config.ts', () => {
       return {
         default: {
@@ -60,6 +93,7 @@ describe('readConfig', () => {
           workerMinify: true,
           workerName: 'sw',
           workerSourcemap: true,
+          workerBuildDirectory: 'customer-build-directory/',
         },
       };
     });
@@ -74,7 +108,7 @@ describe('readConfig', () => {
       serverModuleFormat: 'cjs',
       serverPlatform: 'node',
       worker: 'custom-service-worker.js',
-      workerBuildDirectory: expect.stringContaining('public'),
+      workerBuildDirectory: expect.stringContaining('customer-build-directory'),
       workerMinify: true,
       workerName: 'sw',
       workerSourcemap: true,

--- a/packages/dev/worker-build.ts
+++ b/packages/dev/worker-build.ts
@@ -3,14 +3,14 @@ import type { ServerRouteModule } from '@remix-run/server-runtime/dist/routeModu
 import type { ServerRoute } from '@remix-run/server-runtime/dist/routes.js';
 
 throw new Error(
-  "@remix-pwa/dev/worker-build is not meant to be used directly from node_modules." +
-  " It exists to provide type definitions for a virtual module provided" +
-  " by the Remix compiler at build time."
+  '@remix-pwa/dev/worker-build is not meant to be used directly from node_modules.' +
+  ' It exists to provide type definitions for a virtual module provided' +
+  ' by the Remix compiler at build time.'
 );
 
 export interface WorkerLoadContext extends AppLoadContext {
   event: FetchEvent;
-  fetchFromServer: (request_?: Request) => Promise<Response>;
+  fetchFromServer: () => Promise<Response>;
 }
 export type WorkerDataFunctionArgs = Omit<DataFunctionArgs, 'context'> & {
   context: WorkerLoadContext;
@@ -29,7 +29,7 @@ export interface WorkerRouteModule extends ServerRouteModule {
   workerAction?: WorkerActionFunction;
   workerLoader?: WorkerLoaderFunction;
 }
-export interface WorkerRoute extends Omit<ServerRoute,"children"> {
+export interface WorkerRoute extends Omit<ServerRoute, "children"> {
   hasWorkerAction: boolean;
   hasWorkerLoader: boolean;
   module: WorkerRouteModule;
@@ -51,4 +51,3 @@ export interface BuildEntry {
 // These are the types that are actually exported by the virtual module.
 export const entry: BuildEntry = undefined!;
 export const routes: WorkerRouteManifest = undefined!;
-

--- a/packages/worker-runtime/src/service-worker.internal.ts
+++ b/packages/worker-runtime/src/service-worker.internal.ts
@@ -8,12 +8,11 @@ const _self = self as unknown as ServiceWorkerGlobalScope & typeof globalThis;
  * Creates the load context for the worker action and loader.
  */
 function createContext(event: FetchEvent): build.WorkerLoadContext {
-  const request = event.request.clone();
   // getLoadContext is a function exported by the `entry.worker.js`
   const context = build.entry.module.getLoadContext?.(event) || {};
   return {
     event,
-    fetchFromServer: (request_ = request) => fetch(request_),
+    fetchFromServer: () => fetch(event.request),
     // NOTE: we want the user to override the above properties if needed.
     ...context,
   };

--- a/packages/worker-runtime/src/utils/__test__/response.test.ts
+++ b/packages/worker-runtime/src/utils/__test__/response.test.ts
@@ -1,7 +1,7 @@
 import { ErrorResponse } from '@remix-run/router';
 import { describe, expect, test } from 'vitest';
 
-import { errorResponseToJson } from '../response.js';
+import { errorResponseToJson, isRemixResponse } from '../response.js';
 
 describe('errorResponseToJson', () => {
   test('should return a JSON response with the error message and status', () => {
@@ -23,5 +23,14 @@ describe('errorResponseToJson', () => {
   test('should include the X-Remix-Error header', () => {
     const response = errorResponseToJson(new ErrorResponse(500, 'Internal Server Error', {}));
     expect(response.headers.has('X-Remix-Error')).toBeTruthy();
+  });
+
+  test('`true` when the response has any header that starts with `x-remix-`', () => {
+    expect(isRemixResponse(new Response(null, { headers: { 'X-Remix-mock': 'true' } }))).toBeTruthy();
+    expect(isRemixResponse(new Response(null, { headers: { 'x-remix-mock-2': 'true' } }))).toBeTruthy();
+  });
+
+  test('`false` when the response has any header that starts with `x-remix-`', () => {
+    expect(isRemixResponse(new Response(null))).toBeFalsy();
   });
 });

--- a/packages/worker-runtime/src/utils/handle-request.ts
+++ b/packages/worker-runtime/src/utils/handle-request.ts
@@ -19,7 +19,7 @@ import {
 } from '@remix-run/server-runtime/dist/responses.js';
 
 import { createArgumentsFrom, getURLParameters, isActionRequest, isLoaderRequest } from './request.js';
-import { errorResponseToJson } from './response.js';
+import { errorResponseToJson, isRemixResponse } from './response.js';
 
 interface HandleRequestArgs {
   defaultHandler: DefaultFetchHandler;
@@ -100,7 +100,7 @@ async function handleLoader({ event, loadContext, loader, routeId }: HandleLoade
   if (result === undefined) {
     throw new Error(
       `You defined a loader for route "${routeId}" but didn't return ` +
-        `anything from your \`loader\` function. Please return a value or \`null\`.`
+      `anything from your \`loader\` function. Please return a value or \`null\`.`
     );
   }
 
@@ -131,7 +131,7 @@ async function handleAction({ action, event, loadContext, routeId }: HandleActio
   if (result === undefined) {
     throw new Error(
       `You defined an action for route "${routeId}" but didn't return ` +
-        `anything from your \`action\` function. Please return a value or \`null\`.`
+      `anything from your \`action\` function. Please return a value or \`null\`.`
     );
   }
 
@@ -193,6 +193,6 @@ function responseHandler(response: Response): Response {
 
   // Mark all successful responses with a header so we can identify in-flight
   // network errors that are missing this header
-  !response.headers.has('X-Remix-Response') && response.headers.set('X-Remix-Response', 'yes');
+  !isRemixResponse(response) && response.headers.set('X-Remix-Response', 'yes');
   return response;
 }

--- a/packages/worker-runtime/src/utils/response.ts
+++ b/packages/worker-runtime/src/utils/response.ts
@@ -13,3 +13,10 @@ export function errorResponseToJson(errorResponse: ErrorResponse) {
     },
   });
 }
+
+/**
+ * Checks if a response is a Remix response by checking if it has any `X-Remix` headers.
+ */
+export function isRemixResponse(response: Response) {
+  return Array.from(response.headers.keys()).some(key => key.toLowerCase().startsWith('x-remix-'));
+}

--- a/packages/worker-runtime/tsconfig.json
+++ b/packages/worker-runtime/tsconfig.json
@@ -3,7 +3,7 @@
   "exclude": ["dist", "./**/__tests__", "node_modules"],
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["ES2020", "WebWorker"],
+    "lib": ["ES2020", "WebWorker", "WebWorker.Iterable"],
     "composite": true,
     "target": "es2020",
     "module": "nodenext",


### PR DESCRIPTION
In cases where a response catch by the `worker-runtime` is already a Remix valid response the _responseHandler_ shouldn't try to set `X-Remix` custom headers.

The PR also adds support for any javascript related extension as a user entry worker file.