### PR TITLE
fix: parse path parameters from URL

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: ${{ inputs.node-version }}
+          node-version: 18
       - name: Setup Turbo cache
         uses: actions/cache@v3
         with:
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: ${{ inputs.node-version }}
+          node-version: 18
       - name: Setup Turbo cache
         uses: actions/cache@v3
         with:
@@ -69,7 +69,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: ${{ inputs.node-version }}
+          node-version: 18
       - name: Setup Turbo cache
         uses: actions/cache@v3
         with:
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: ${{ inputs.node-version }}
+          node-version: 18
       - name: Setup Turbo cache
         uses: actions/cache@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18420,7 +18420,7 @@
     },
     "packages/cache": {
       "name": "@remix-pwa/cache",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "cachified": "^3.5.4"
@@ -18447,10 +18447,10 @@
     },
     "packages/dev": {
       "name": "@remix-pwa/dev",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "@remix-pwa/worker-runtime": "^1.0.2",
+        "@remix-pwa/worker-runtime": "^1.1.0",
         "@remix-run/dev": "^1.19.2",
         "arg": "^5.0.2",
         "colorette": "^2.0.20",
@@ -18663,10 +18663,10 @@
     },
     "packages/strategy": {
       "name": "@remix-pwa/strategy",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@remix-pwa/cache": "^1.2.1"
+        "@remix-pwa/cache": "^1.3.0"
       },
       "devDependencies": {
         "@remix-pwa/eslint-config": "^0.0.0",
@@ -18676,15 +18676,15 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@remix-pwa/cache": "^1.2.1"
+        "@remix-pwa/cache": "^1.3.0"
       }
     },
     "packages/sw": {
       "name": "@remix-pwa/sw",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@remix-pwa/cache": "^1.2.1",
+        "@remix-pwa/cache": "^1.3.0",
         "@remix-run/dev": "^1.19.3",
         "@remix-run/react": "^1.19.3",
         "react": "^18.2.0",
@@ -18700,7 +18700,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@remix-pwa/cache": "^1.2.1"
+        "@remix-pwa/cache": "^1.3.0"
       }
     },
     "packages/sw/node_modules/brace-expansion": {
@@ -18808,7 +18808,7 @@
     },
     "packages/sync": {
       "name": "@remix-pwa/sync",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "idb": "^7.1.1"
@@ -18897,7 +18897,7 @@
     },
     "packages/worker-runtime": {
       "name": "@remix-pwa/worker-runtime",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "^1.7.2",
@@ -18921,7 +18921,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@remix-pwa/strategy": "1.0.0",
+        "@remix-pwa/strategy": "1.0.1",
         "@remix-pwa/sw": "1.1.3",
         "@remix-pwa/sync": "^1.0.0",
         "@remix-pwa/worker-runtime": "^1.0.0",

--- a/packages/worker-runtime/src/utils/__test__/handle-request.test.ts
+++ b/packages/worker-runtime/src/utils/__test__/handle-request.test.ts
@@ -1,4 +1,5 @@
 import type { WorkerLoadContext, WorkerRoute, WorkerRouteManifest } from '@remix-pwa/dev/worker-build.js';
+import { defer } from '@remix-run/router';
 import { describe, expect, test, vi } from 'vitest';
 
 import { handleRequest } from '../handle-request.js';
@@ -16,13 +17,36 @@ describe('handleRequest', () => {
     const event = {
       request: new Request('https://example.com/route1?_data=route1'),
     } as FetchEvent;
-    const defaultHandler = vi.fn(() => new Response('Default handler response'));
-    const errorHandler = vi.fn(() => new Response('Error handler response'));
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
     const loadContext = {} as WorkerLoadContext;
     const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
 
     expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
     await expect(response.json()).resolves.toEqual({ message: 'Hello, world!' });
+  });
+
+  test('should not wrap worker loader response in a json when returning a response', async () => {
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerLoader: vi.fn().mockReturnValue(new Response('mock-response', { status: 200 })),
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1'),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).not.toBe('application/json; charset=utf-8');
+    expect(await response.text()).toBe('mock-response');
   });
 
   test('should handle action requests', async () => {
@@ -37,8 +61,8 @@ describe('handleRequest', () => {
     const event = {
       request: new Request('https://example.com/route1?_data=route1&action=true', { method: 'POST' }),
     } as FetchEvent;
-    const defaultHandler = vi.fn(() => new Response('Default handler response'));
-    const errorHandler = vi.fn(() => new Response('Error handler response'));
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
     const loadContext = {} as WorkerLoadContext;
     const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
 
@@ -52,7 +76,7 @@ describe('handleRequest', () => {
       request: new Request('https://example.com/route2'),
     } as FetchEvent;
     const defaultHandler = vi.fn(() => new Response('Default handler response'));
-    const errorHandler = vi.fn(() => new Response('Error handler response'));
+    const errorHandler = vi.fn();
     const loadContext = {} as WorkerLoadContext;
 
     const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
@@ -81,16 +105,401 @@ describe('handleRequest', () => {
     const event = {
       request: new Request('https://example.com/route1?_data=route1'),
     } as FetchEvent;
-    const defaultHandler = vi.fn(() => new Response('Default handler response'));
+    const defaultHandler = vi.fn();
     const loadContext = {} as WorkerLoadContext;
     const response = await handleRequest({ routes, event, defaultHandler, errorHandler: handler, loadContext });
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(error, {
-      params: {},
-      request: expect.any(Request),
+      params: {
+        _data: 'route1',
+      },
+      request: event.request,
       context: loadContext,
     });
     expect(response.status).toBe(500);
+  });
+
+  test('should return a 204 and add Remix Headers on a redirect response', async () => {
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: vi.fn().mockReturnValue(new Response(null, { status: 302, headers: { Location: '/route2' } })),
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1&action=true', { method: 'POST' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+    expect(response.status).toBe(204);
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'x-remix-redirect': '/route2',
+      'x-remix-status': '302',
+    });
+  });
+
+  test('should force a revalidate on redirect', async () => {
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: vi
+            .fn()
+            .mockReturnValue(
+              new Response(null, { status: 302, headers: { Location: '/route2', 'Set-Cookie': 'mock-cookie-value' } })
+            ),
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1&action=true', { method: 'POST' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+    expect(response.status).toBe(204);
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'x-remix-redirect': '/route2',
+      'x-remix-status': '302',
+      'x-remix-revalidate': 'yes',
+      'set-cookie': 'mock-cookie-value',
+    });
+  });
+
+  test('should mark the response as a Remix Response', async () => {
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: vi.fn().mockReturnValue(new Response('Remix response', { status: 200 })),
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1&action=true', { method: 'POST' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+    expect(response.status).toBe(200);
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'text/plain;charset=UTF-8',
+      'x-remix-response': 'yes',
+    });
+  });
+
+  test('should call a worker action with search params', async () => {
+    const mockWorkerAction = vi.fn().mockReturnValue(new Response('Remix response', { status: 200 }));
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: mockWorkerAction,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1&query=this is a test', { method: 'POST' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerAction).toHaveBeenCalledWith({
+      request: expect.anything(),
+      params: { query: 'this is a test' },
+      context: loadContext,
+    });
+  });
+
+  test('should call a worker action with path params', async () => {
+    const mockWorkerAction = vi.fn().mockReturnValue(new Response('Remix response', { status: 200 }));
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: mockWorkerAction,
+        },
+        path: '/route1/:id',
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1/route-id?_data=route1', { method: 'POST' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerAction).toHaveBeenCalledWith({
+      request: expect.anything(),
+      params: { id: 'route-id' },
+      context: loadContext,
+    });
+  });
+
+  test('should be able to consume given request in a worker action', async () => {
+    const mockWorkerAction = vi.fn(async ({ request }) => {
+      const text = await request.text();
+      throw new Error(text);
+    });
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: mockWorkerAction,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'POST', body: 'mock-error' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerAction).toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalled();
+    expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    expect(response.headers.get('x-remix-error')).toBe('yes');
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ message: 'mock-error' });
+  });
+
+  test('should be able to consume the original request in a worker action', async () => {
+    const mockWorkerAction = vi.fn(async ({ context }) => {
+      const text = await context.event.request.text();
+      throw new Error(text);
+    });
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: mockWorkerAction,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'POST', body: 'mock-error-original' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = { event } as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerAction).toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalledWith(expect.any(Error), {
+      context: loadContext,
+      request: event.request,
+      params: {
+        _data: 'route1',
+      },
+    });
+    expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    expect(response.headers.get('x-remix-error')).toBe('yes');
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ message: 'mock-error-original' });
+  });
+
+  test('should be able to throw a RouteErrorResponse and not call the error handler', async () => {
+    const mockWorkerAction = vi.fn(async ({ request }) => {
+      const text = await request.text();
+      const errorResponse = {
+        status: 500,
+        statusText: 'Internal Server Error',
+        internal: true,
+        data: {
+          message: text,
+        },
+      };
+      throw errorResponse;
+    });
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: mockWorkerAction,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'POST', body: 'mock-error-original' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = { event } as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerAction).toHaveBeenCalled();
+    expect(errorHandler).not.toHaveBeenCalled();
+    expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    expect(response.headers.get('x-remix-error')).toBe('yes');
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ message: 'Unexpected Server Error' });
+  });
+
+  test('should be able to throw a RouteErrorResponse and pass the error to the error handler', async () => {
+    const mockWorkerAction = vi.fn(async ({ request }) => {
+      const text = await request.text();
+      const errorResponse = {
+        status: 500,
+        statusText: 'Internal Server Error',
+        internal: true,
+        data: {
+          message: text,
+        },
+        error: new Error('Internal server error'),
+      };
+      throw errorResponse;
+    });
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: mockWorkerAction,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'POST', body: 'mock-error-original' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = { event } as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerAction).toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalled();
+
+    expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    expect(response.headers.get('x-remix-error')).toBe('yes');
+    expect(response.status).toBe(500);
+  });
+
+  test('should not call the error handler when throwing a response', async () => {
+    const mockWorkerAction = vi.fn(async () => {
+      throw new Response('Response error', { status: 500 });
+    });
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerAction: mockWorkerAction,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'POST', body: 'mock-body' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerAction).toHaveBeenCalled();
+    expect(errorHandler).not.toHaveBeenCalled();
+    expect(response.headers.get('x-remix-catch')).toBe('yes');
+    await expect(response.text()).resolves.toBe('Response error');
+  });
+
+  test('should handle stream data in a worker loader with a redirect', async () => {
+    const mockWorkerLoader = vi
+      .fn()
+      .mockReturnValue(
+        defer({ promise: Promise.resolve('mock-promise') }, { status: 302, headers: { Location: '/route2' } })
+      );
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerLoader: mockWorkerLoader,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'GET' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerLoader).toHaveBeenCalled();
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'x-remix-redirect': '/route2',
+      'x-remix-status': '302',
+    });
+    expect(response.status).toBe(204);
+  });
+
+  test('should handle stream data in a worker loader', async () => {
+    const mockWorkerLoader = vi.fn().mockReturnValue(defer({ promise: Promise.resolve('mock-promise') }, undefined));
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerLoader: mockWorkerLoader,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'GET' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerLoader).toHaveBeenCalled();
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'text/remix-deferred',
+      'x-remix-response': 'yes',
+    });
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain('mock-promise');
+  });
+
+  test('should handle stream data in a worker loader and use the given response init', async () => {
+    const mockWorkerLoader = vi
+      .fn()
+      .mockReturnValue(
+        defer(
+          { promise: Promise.resolve('mock-promise') },
+          { status: 500, headers: { 'x-mock-header': 'mock-header-value' } }
+        )
+      );
+    const routes = {
+      route1: {
+        id: 'route1',
+        module: {
+          workerLoader: mockWorkerLoader,
+        },
+      } as unknown as WorkerRoute,
+    };
+    const event = {
+      request: new Request('https://example.com/route1?_data=route1', { method: 'GET' }),
+    } as FetchEvent;
+    const defaultHandler = vi.fn();
+    const errorHandler = vi.fn();
+    const loadContext = {} as WorkerLoadContext;
+    const response = await handleRequest({ routes, event, defaultHandler, errorHandler, loadContext });
+
+    expect(mockWorkerLoader).toHaveBeenCalled();
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'text/remix-deferred',
+      'x-remix-response': 'yes',
+      'x-mock-header': 'mock-header-value',
+    });
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.toContain('mock-promise');
   });
 });

--- a/packages/worker-runtime/src/utils/request.ts
+++ b/packages/worker-runtime/src/utils/request.ts
@@ -1,4 +1,5 @@
 import type { WorkerLoadContext } from '@remix-pwa/dev/worker-build.js';
+import { matchPath } from '@remix-run/router';
 
 /**
  * Clones an object
@@ -14,8 +15,14 @@ export function clone<T extends Record<string | number | symbol, unknown> | Requ
 /**
  * Gets the URL search parameters from a request.
  */
-export function getURLParameters(request: Request): Record<string, string> {
-  return Object.fromEntries(new URL(request.url).searchParams.entries());
+export function getURLParameters(request: Request, path: string = ''): Record<string, string | undefined> {
+  const url = new URL(request.url);
+  const match = matchPath(path, url.pathname);
+
+  return {
+    ...Object.fromEntries(new URL(request.url).searchParams.entries()),
+    ...match?.params,
+  };
 }
 
 /**
@@ -55,9 +62,17 @@ export function stripDataParameter(request: Request): Request {
 /**
  * Creates arguments for the Worker Actions and Loaders.
  */
-export function createArgumentsFrom({ event, loadContext }: { event: FetchEvent; loadContext: WorkerLoadContext }) {
+export function createArgumentsFrom({
+  event,
+  loadContext,
+  path,
+}: {
+  event: FetchEvent;
+  loadContext: WorkerLoadContext;
+  path?: string;
+}) {
   const request = stripDataParameter(stripIndexParameter(event.request.clone()));
-  const parameters = getURLParameters(request);
+  const parameters = getURLParameters(request, path);
 
   return {
     request,

--- a/packages/worker-runtime/src/utils/response.ts
+++ b/packages/worker-runtime/src/utils/response.ts
@@ -5,7 +5,7 @@ import { json } from '@remix-run/server-runtime/dist/responses.js';
  * Converts an error response to a JSON response.
  */
 export function errorResponseToJson(errorResponse: ErrorResponse) {
-  return json(errorResponse.error || new Error('Unexpected Server Error'), {
+  return json(errorResponse.error || { message: 'Unexpected Server Error' }, {
     status: errorResponse.status,
     statusText: errorResponse.statusText,
     headers: {

--- a/playground/package.json
+++ b/playground/package.json
@@ -18,7 +18,7 @@
     "dev:remix": "remix dev"
   },
   "dependencies": {
-    "@remix-pwa/strategy": "1.0.0",
+    "@remix-pwa/strategy": "^1.0.1",
     "@remix-pwa/sw": "1.1.3",
     "@remix-pwa/sync": "^1.0.0",
     "@remix-pwa/worker-runtime": "^1.0.0",

--- a/playground/remix.config.js
+++ b/playground/remix.config.js
@@ -12,11 +12,11 @@ module.exports = {
   },
   tailwind: true,
   serverDependenciesToBundle: [
-    '@remix-pwa/sw', 
-    '@remix-pwa/strategy', 
-    '@remix-pwa/dev', 
-    '@remix-pwa/sync', 
-    '@remix-pwa/cache', 
+    '@remix-pwa/sw',
+    '@remix-pwa/strategy',
+    '@remix-pwa/dev',
+    '@remix-pwa/sync',
+    '@remix-pwa/cache',
     'idb'
   ]
 };


### PR DESCRIPTION
- Adds support for route path parameters plus query string parameters
- Adds more test about error handler, defer data, worker loaders and actions different kind of responses.
- Replace old inputs in validation workflows with actual node version value