### PR TITLE
Fix for ESM Remix projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1056,6 +1056,51 @@
         "node": ">=16"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.19.4",
       "cpu": [
@@ -1065,6 +1110,276 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -1613,6 +1928,51 @@
         }
       }
     },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/android-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.6.tgz",
+      "integrity": "sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.6.tgz",
+      "integrity": "sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/android-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.6.tgz",
+      "integrity": "sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@remix-run/dev/node_modules/@esbuild/darwin-arm64": {
       "version": "0.17.6",
       "cpu": [
@@ -1622,6 +1982,276 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.6.tgz",
+      "integrity": "sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.6.tgz",
+      "integrity": "sha512-EnUwjRc1inT4ccZh4pB3v1cIhohE2S4YXlt1OvI7sw/+pD+dIE4smwekZlEPIwY6PhU6oDWwITrQQm5S2/iZgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.6.tgz",
+      "integrity": "sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.6.tgz",
+      "integrity": "sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.6.tgz",
+      "integrity": "sha512-bUR58IFOMJX523aDVozswnlp5yry7+0cRLCXDsxnUeQYJik1DukMY+apBsLOZJblpH+K7ox7YrKrHmJoWqVR9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.6.tgz",
+      "integrity": "sha512-ujp8uoQCM9FRcbDfkqECoARsLnLfCUhKARTP56TFPog8ie9JG83D5GVKjQ6yVrEVdMie1djH86fm98eY3quQkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.6.tgz",
+      "integrity": "sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.6.tgz",
+      "integrity": "sha512-09AXKB1HDOzXD+j3FdXCiL/MWmZP0Ex9eR8DLMBVcHorrWJxWmY8Nms2Nm41iRM64WVx7bA/JVHMv081iP2kUA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.6.tgz",
+      "integrity": "sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.6.tgz",
+      "integrity": "sha512-Y4Ri62PfavhLQhFbqucysHOmRamlTVK10zPWlqjNbj2XMea+BOs4w6ASKwQwAiqf9ZqcY9Ab7NOU4wIgpxwoSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.6.tgz",
+      "integrity": "sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.6.tgz",
+      "integrity": "sha512-a3yHLmOodHrzuNgdpB7peFGPx1iJ2x6m+uDvhP2CKdr2CwOaqEFMeSqYAHU7hG+RjCq8r2NFujcd/YsEsFgTGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.6.tgz",
+      "integrity": "sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.6.tgz",
+      "integrity": "sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.6.tgz",
+      "integrity": "sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.6.tgz",
+      "integrity": "sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -2331,6 +2961,51 @@
         "vite-node": "^0.28.5"
       }
     },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/android-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.6.tgz",
+      "integrity": "sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.6.tgz",
+      "integrity": "sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/android-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.6.tgz",
+      "integrity": "sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@vanilla-extract/integration/node_modules/@esbuild/darwin-arm64": {
       "version": "0.17.6",
       "cpu": [
@@ -2340,6 +3015,276 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.6.tgz",
+      "integrity": "sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.6.tgz",
+      "integrity": "sha512-EnUwjRc1inT4ccZh4pB3v1cIhohE2S4YXlt1OvI7sw/+pD+dIE4smwekZlEPIwY6PhU6oDWwITrQQm5S2/iZgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.6.tgz",
+      "integrity": "sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.6.tgz",
+      "integrity": "sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.6.tgz",
+      "integrity": "sha512-bUR58IFOMJX523aDVozswnlp5yry7+0cRLCXDsxnUeQYJik1DukMY+apBsLOZJblpH+K7ox7YrKrHmJoWqVR9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.6.tgz",
+      "integrity": "sha512-ujp8uoQCM9FRcbDfkqECoARsLnLfCUhKARTP56TFPog8ie9JG83D5GVKjQ6yVrEVdMie1djH86fm98eY3quQkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.6.tgz",
+      "integrity": "sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.6.tgz",
+      "integrity": "sha512-09AXKB1HDOzXD+j3FdXCiL/MWmZP0Ex9eR8DLMBVcHorrWJxWmY8Nms2Nm41iRM64WVx7bA/JVHMv081iP2kUA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.6.tgz",
+      "integrity": "sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.6.tgz",
+      "integrity": "sha512-Y4Ri62PfavhLQhFbqucysHOmRamlTVK10zPWlqjNbj2XMea+BOs4w6ASKwQwAiqf9ZqcY9Ab7NOU4wIgpxwoSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.6.tgz",
+      "integrity": "sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.6.tgz",
+      "integrity": "sha512-a3yHLmOodHrzuNgdpB7peFGPx1iJ2x6m+uDvhP2CKdr2CwOaqEFMeSqYAHU7hG+RjCq8r2NFujcd/YsEsFgTGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.6.tgz",
+      "integrity": "sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.6.tgz",
+      "integrity": "sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.6.tgz",
+      "integrity": "sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vanilla-extract/integration/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.6.tgz",
+      "integrity": "sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -3071,6 +4016,30 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-browser": {
+      "name": "buffer",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -4600,6 +5569,321 @@
       },
       "peerDependencies": {
         "esbuild": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.4.tgz",
+      "integrity": "sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.4.tgz",
+      "integrity": "sha512-mRsi2vJsk4Bx/AFsNBqOH2fqedxn5L/moT58xgg51DjX1la64Z3Npicut2VbhvDFO26qjWtPMsVxCd80YTFVeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.4.tgz",
+      "integrity": "sha512-4iPufZ1TMOD3oBlGFqHXBpa3KFT46aLl6Vy7gwed0ZSYgHaZ/mihbYb4t7Z9etjkC9Al3ZYIoOaHrU60gcMy7g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.4.tgz",
+      "integrity": "sha512-YHbSFlLgDwglFn0lAO3Zsdrife9jcQXQhgRp77YiTDja23FrC2uwnhXMNkAucthsf+Psr7sTwYEryxz6FPAVqw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.4.tgz",
+      "integrity": "sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.4.tgz",
+      "integrity": "sha512-3sRbQ6W5kAiVQRBWREGJNd1YE7OgzS0AmOGjDmX/qZZecq8NFlQsQH0IfXjjmD0XtUYqr64e0EKNFjMUlPL3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.4.tgz",
+      "integrity": "sha512-z/4ArqOo9EImzTi4b6Vq+pthLnepFzJ92BnofU1jgNlcVb+UqynVFdoXMCFreTK7FdhqAzH0vmdwW5373Hm9pg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.4.tgz",
+      "integrity": "sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.4.tgz",
+      "integrity": "sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.4.tgz",
+      "integrity": "sha512-WVhIKO26kmm8lPmNrUikxSpXcgd6HDog0cx12BUfA2PkmURHSgx9G6vA19lrlQOMw+UjMZ+l3PpbtzffCxFDRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.4.tgz",
+      "integrity": "sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.4.tgz",
+      "integrity": "sha512-tQ92n0WMXyEsCH4m32S21fND8VxNiVazUbU4IUGVXQpWiaAxOBvtOtbEt3cXIV3GEBydYsY8pyeRMJx9kn3rvw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.4.tgz",
+      "integrity": "sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.4.tgz",
+      "integrity": "sha512-152aLpQqKZYhThiJ+uAM4PcuLCAOxDsCekIbnGzPKVBRUDlgaaAfaUl5NYkB1hgY6WN4sPkejxKlANgVcGl9Qg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.4.tgz",
+      "integrity": "sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.4.tgz",
+      "integrity": "sha512-9+Wxx1i5N/CYo505CTT7T+ix4lVzEdz0uCoYGxM5JDVlP2YdDC1Bdz+Khv6IbqmisT0Si928eAxbmGkcbiuM/A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.4.tgz",
+      "integrity": "sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.4.tgz",
+      "integrity": "sha512-6Xq8SpK46yLvrGxjp6HftkDwPP49puU4OF0hEL4dTxqCbfx09LyrbUj/D7tmIRMj5D5FCUPksBbxyQhp8tmHzw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.4.tgz",
+      "integrity": "sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.4.tgz",
+      "integrity": "sha512-ga676Hnvw7/ycdKB53qPusvsKdwrWzEyJ+AtItHGoARszIqvjffTwaaW3b2L6l90i7MO9i+dlAW415INuRhSGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.4.tgz",
+      "integrity": "sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/escalade": {
@@ -12589,6 +13873,76 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
+      "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "get-tsconfig": "^4.7.2",
+        "source-map-support": "^0.5.21"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
     "node_modules/turbo": {
       "version": "1.10.14",
       "dev": true,
@@ -13648,7 +15002,7 @@
       "version": "2.0.12",
       "license": "MIT",
       "dependencies": {
-        "buffer": "^6.0.3",
+        "buffer-browser": "npm:buffer@^6.0.3",
         "cachified": "^3.5.4"
       },
       "devDependencies": {
@@ -13657,28 +15011,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "packages/cache/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "packages/client": {
@@ -14312,7 +15644,7 @@
         "npm-run-all": "^4.1.5",
         "remix-pwa": "^3.0.17",
         "tailwindcss": "^3.3.3",
-        "ts-node": "^10.9.1",
+        "tsx": "^3.14.0",
         "typescript": "^5.2.2"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -76,6 +77,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.22.13",
@@ -87,6 +89,7 @@
     },
     "node_modules/@babel/code-frame/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -97,6 +100,7 @@
     },
     "node_modules/@babel/code-frame/node_modules/chalk": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -109,6 +113,7 @@
     },
     "node_modules/@babel/code-frame/node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -116,10 +121,12 @@
     },
     "node_modules/@babel/code-frame/node_modules/color-name": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -127,6 +134,7 @@
     },
     "node_modules/@babel/code-frame/node_modules/has-flag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -134,6 +142,7 @@
     },
     "node_modules/@babel/code-frame/node_modules/supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -144,6 +153,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.22.20",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -151,6 +161,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -179,6 +190,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -211,6 +223,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.23.0",
@@ -224,6 +237,7 @@
     },
     "node_modules/@babel/generator/node_modules/jsesc": {
       "version": "2.5.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -234,6 +248,7 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -244,6 +259,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.22.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
@@ -258,6 +274,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -265,6 +282,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.22.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -286,6 +304,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -293,6 +312,7 @@
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -300,6 +320,7 @@
     },
     "node_modules/@babel/helper-function-name": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.22.15",
@@ -311,6 +332,7 @@
     },
     "node_modules/@babel/helper-hoist-variables": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -321,6 +343,7 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.23.0"
@@ -331,6 +354,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.22.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.15"
@@ -341,6 +365,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -358,6 +383,7 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -368,6 +394,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -375,6 +402,7 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.22.20",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -390,6 +418,7 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -400,6 +429,7 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -410,6 +440,7 @@
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.22.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -420,6 +451,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -427,6 +459,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.22.20",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -434,6 +467,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.22.15",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -441,6 +475,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.23.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.22.15",
@@ -453,6 +488,7 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.22.20",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -465,6 +501,7 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -475,6 +512,7 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -487,6 +525,7 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -494,10 +533,12 @@
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -505,6 +546,7 @@
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -512,6 +554,7 @@
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -522,6 +565,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -532,6 +576,7 @@
     },
     "node_modules/@babel/plugin-syntax-decorators": {
       "version": "7.22.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -545,6 +590,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -558,6 +604,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.22.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -571,6 +618,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.23.0",
@@ -647,6 +695,7 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.22.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -682,6 +731,7 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -699,6 +749,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.23.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -709,6 +760,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
@@ -721,6 +773,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
@@ -740,6 +793,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -1022,7 +1076,7 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -1033,7 +1087,7 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1042,6 +1096,7 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -1549,6 +1604,7 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1564,6 +1620,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1574,6 +1631,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1589,6 +1647,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1620,6 +1679,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -1632,6 +1692,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1639,6 +1700,7 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1650,6 +1712,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.19",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1657,10 +1720,12 @@
       }
     },
     "node_modules/@jspm/core": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "node_modules/@mdx-js/mdx": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -1725,6 +1790,7 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "semver": "^7.3.5"
@@ -1735,6 +1801,7 @@
     },
     "node_modules/@npmcli/git": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/promise-spawn": "^6.0.0",
@@ -1752,6 +1819,7 @@
     },
     "node_modules/@npmcli/git/node_modules/lru-cache": {
       "version": "7.18.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1759,6 +1827,7 @@
     },
     "node_modules/@npmcli/package-json": {
       "version": "4.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^4.1.0",
@@ -1775,6 +1844,7 @@
     },
     "node_modules/@npmcli/promise-spawn": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "which": "^3.0.0"
@@ -1785,6 +1855,7 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1858,6 +1929,7 @@
     },
     "node_modules/@remix-run/dev": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -1935,6 +2007,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1950,6 +2023,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1965,6 +2039,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1978,6 +2053,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,6 +2070,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2009,6 +2086,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2024,6 +2102,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2039,6 +2118,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2054,6 +2134,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2069,6 +2150,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2084,6 +2166,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2099,6 +2182,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2114,6 +2198,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2129,6 +2214,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2144,6 +2230,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2159,6 +2246,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2174,6 +2262,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -2189,6 +2278,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -2204,6 +2294,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -2219,6 +2310,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2234,6 +2326,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2249,6 +2342,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2259,6 +2353,7 @@
     },
     "node_modules/@remix-run/dev/node_modules/esbuild": {
       "version": "0.17.6",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2294,6 +2389,7 @@
     },
     "node_modules/@remix-run/dev/node_modules/fs-extra": {
       "version": "10.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2306,6 +2402,7 @@
     },
     "node_modules/@remix-run/dev/node_modules/prettier": {
       "version": "2.8.8",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
@@ -2545,26 +2642,27 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -2600,6 +2698,7 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -2616,10 +2715,12 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -2636,6 +2737,7 @@
     },
     "node_modules/@types/hast": {
       "version": "2.3.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2"
@@ -2664,6 +2766,7 @@
     },
     "node_modules/@types/mdast": {
       "version": "3.0.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2"
@@ -2671,6 +2774,7 @@
     },
     "node_modules/@types/mdx": {
       "version": "2.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -2680,6 +2784,7 @@
     },
     "node_modules/@types/ms": {
       "version": "0.7.32",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2725,6 +2830,7 @@
     },
     "node_modules/@types/unist": {
       "version": "2.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2920,6 +3026,7 @@
     },
     "node_modules/@vanilla-extract/babel-plugin-debug-ids": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.7"
@@ -2927,6 +3034,7 @@
     },
     "node_modules/@vanilla-extract/css": {
       "version": "1.13.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
@@ -2944,6 +3052,7 @@
     },
     "node_modules/@vanilla-extract/integration": {
       "version": "6.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.7",
@@ -2968,6 +3077,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2983,6 +3093,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2998,6 +3109,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -3011,6 +3123,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3027,6 +3140,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3042,6 +3156,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3057,6 +3172,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3072,6 +3188,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3087,6 +3204,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3102,6 +3220,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3117,6 +3236,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3132,6 +3252,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3147,6 +3268,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3162,6 +3284,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3177,6 +3300,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3192,6 +3316,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3207,6 +3332,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -3222,6 +3348,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -3237,6 +3364,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -3252,6 +3380,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3267,6 +3396,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3282,6 +3412,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3292,6 +3423,7 @@
     },
     "node_modules/@vanilla-extract/integration/node_modules/esbuild": {
       "version": "0.17.6",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3327,6 +3459,7 @@
     },
     "node_modules/@vanilla-extract/private": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
@@ -3542,6 +3675,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
@@ -3553,6 +3687,7 @@
     },
     "node_modules/ahocorasick": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv": {
@@ -3790,6 +3925,7 @@
     },
     "node_modules/astring": {
       "version": "1.8.6",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
@@ -3831,6 +3967,7 @@
     },
     "node_modules/bail": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3885,6 +4022,7 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -3944,6 +4082,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3961,6 +4100,7 @@
     },
     "node_modules/browserify-zlib": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pako": "~0.2.0"
@@ -3968,6 +4108,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.22.1",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3998,6 +4139,7 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4068,6 +4210,7 @@
     },
     "node_modules/cacache": {
       "version": "17.1.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
@@ -4089,6 +4232,7 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "7.18.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4150,6 +4294,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001543",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4168,6 +4313,7 @@
     },
     "node_modules/ccount": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4206,6 +4352,7 @@
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4214,6 +4361,7 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4222,6 +4370,7 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4230,6 +4379,7 @@
     },
     "node_modules/character-reference-invalid": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4278,6 +4428,7 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -4285,6 +4436,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4429,6 +4581,7 @@
     },
     "node_modules/clone": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -4454,6 +4607,7 @@
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4601,6 +4755,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -4619,6 +4774,7 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -4787,7 +4943,7 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-env": {
@@ -4835,6 +4991,7 @@
     },
     "node_modules/css-what": {
       "version": "6.1.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -4845,6 +5002,7 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4855,6 +5013,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4925,6 +5084,7 @@
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -4978,10 +5138,12 @@
     },
     "node_modules/deep-object-diff": {
       "version": "1.1.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5113,6 +5275,7 @@
     },
     "node_modules/defaults": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
@@ -5167,6 +5330,7 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5194,7 +5358,7 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -5261,6 +5425,7 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.0.0",
@@ -5271,10 +5436,12 @@
     },
     "node_modules/duplexify/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -5288,6 +5455,7 @@
     },
     "node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -5303,10 +5471,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.540",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5318,6 +5488,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -5347,6 +5518,7 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -5534,6 +5706,7 @@
     },
     "node_modules/esbuild-plugins-node-modules-polyfill": {
       "version": "1.6.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jspm/core": "^2.0.1",
@@ -5864,6 +6037,7 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6883,6 +7057,7 @@
     },
     "node_modules/estree-util-attach-comments": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -6894,6 +7069,7 @@
     },
     "node_modules/estree-util-build-jsx": {
       "version": "2.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -6907,6 +7083,7 @@
     },
     "node_modules/estree-util-is-identifier-name": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6915,6 +7092,7 @@
     },
     "node_modules/estree-util-to-js": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -6928,6 +7106,7 @@
     },
     "node_modules/estree-util-value-to-estree": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
@@ -6938,6 +7117,7 @@
     },
     "node_modules/estree-util-value-to-estree/node_modules/is-plain-obj": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6948,6 +7128,7 @@
     },
     "node_modules/estree-util-visit": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -6960,6 +7141,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -6981,6 +7163,7 @@
     },
     "node_modules/eval": {
       "version": "0.1.8",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "require-like": ">= 0.1.1"
@@ -7024,6 +7207,7 @@
     },
     "node_modules/exit-hook": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7114,6 +7298,7 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/external-editor": {
@@ -7168,6 +7353,7 @@
     },
     "node_modules/fault": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "format": "^0.2.0"
@@ -7282,6 +7468,7 @@
     },
     "node_modules/foreground-child": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -7296,6 +7483,7 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7306,6 +7494,7 @@
     },
     "node_modules/format": {
       "version": "0.2.2",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -7326,6 +7515,7 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -7342,6 +7532,7 @@
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
@@ -7394,6 +7585,7 @@
     },
     "node_modules/generic-names": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loader-utils": "^3.2.0"
@@ -7401,6 +7593,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7498,6 +7691,7 @@
     },
     "node_modules/glob": {
       "version": "10.3.10",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -7539,6 +7733,7 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7595,6 +7790,7 @@
     },
     "node_modules/gunzip-maybe": {
       "version": "1.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserify-zlib": "^0.1.4",
@@ -7610,10 +7806,12 @@
     },
     "node_modules/gunzip-maybe/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/gunzip-maybe/node_modules/readable-stream": {
       "version": "2.3.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -7627,6 +7825,7 @@
     },
     "node_modules/gunzip-maybe/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -7634,6 +7833,7 @@
     },
     "node_modules/gunzip-maybe/node_modules/through2": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -7714,6 +7914,7 @@
     },
     "node_modules/hast-util-to-estree": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -7739,6 +7940,7 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -7747,6 +7949,7 @@
     },
     "node_modules/hosted-git-info": {
       "version": "6.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^7.5.1"
@@ -7757,6 +7960,7 @@
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "7.18.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7814,6 +8018,7 @@
     },
     "node_modules/icss-utils": {
       "version": "5.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -7881,6 +8086,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7905,6 +8111,7 @@
     },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/inquirer": {
@@ -8034,6 +8241,7 @@
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8042,6 +8250,7 @@
     },
     "node_modules/is-alphanumerical": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
@@ -8133,6 +8342,7 @@
     },
     "node_modules/is-buffer": {
       "version": "2.0.5",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8200,6 +8410,7 @@
     },
     "node_modules/is-decimal": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8208,6 +8419,7 @@
     },
     "node_modules/is-deflate": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-docker": {
@@ -8277,6 +8489,7 @@
     },
     "node_modules/is-gzip": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8284,6 +8497,7 @@
     },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8308,6 +8522,7 @@
     },
     "node_modules/is-interactive": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8376,6 +8591,7 @@
     },
     "node_modules/is-reference": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -8475,6 +8691,7 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8619,6 +8836,7 @@
     },
     "node_modules/jackspeak": {
       "version": "2.3.6",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -8635,6 +8853,7 @@
     },
     "node_modules/javascript-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jiti": {
@@ -8668,6 +8887,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -8687,6 +8907,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -8703,6 +8924,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -8791,6 +9013,7 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8822,6 +9045,7 @@
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9023,6 +9247,7 @@
     },
     "node_modules/loader-utils": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -9053,14 +9278,17 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isfunction": {
@@ -9109,6 +9337,7 @@
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -9220,6 +9449,7 @@
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9245,6 +9475,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -9284,7 +9515,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/map-obj": {
@@ -9300,6 +9531,7 @@
     },
     "node_modules/markdown-extensions": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9307,6 +9539,7 @@
     },
     "node_modules/mdast-util-definitions": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -9320,6 +9553,7 @@
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -9342,6 +9576,7 @@
     },
     "node_modules/mdast-util-frontmatter": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -9355,6 +9590,7 @@
     },
     "node_modules/mdast-util-mdx": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^1.0.0",
@@ -9370,6 +9606,7 @@
     },
     "node_modules/mdast-util-mdx-expression": {
       "version": "1.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -9385,6 +9622,7 @@
     },
     "node_modules/mdast-util-mdx-jsx": {
       "version": "2.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -9407,6 +9645,7 @@
     },
     "node_modules/mdast-util-mdxjs-esm": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -9422,6 +9661,7 @@
     },
     "node_modules/mdast-util-phrasing": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -9434,6 +9674,7 @@
     },
     "node_modules/mdast-util-to-hast": {
       "version": "12.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
@@ -9452,6 +9693,7 @@
     },
     "node_modules/mdast-util-to-markdown": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -9470,6 +9712,7 @@
     },
     "node_modules/mdast-util-to-string": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0"
@@ -9481,6 +9724,7 @@
     },
     "node_modules/media-query-parser": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -9600,6 +9844,7 @@
     },
     "node_modules/micromark": {
       "version": "3.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9633,6 +9878,7 @@
     },
     "node_modules/micromark-core-commonmark": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9665,6 +9911,7 @@
     },
     "node_modules/micromark-extension-frontmatter": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fault": "^2.0.0",
@@ -9679,6 +9926,7 @@
     },
     "node_modules/micromark-extension-mdx-expression": {
       "version": "1.0.8",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9703,6 +9951,7 @@
     },
     "node_modules/micromark-extension-mdx-jsx": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/acorn": "^4.0.0",
@@ -9723,6 +9972,7 @@
     },
     "node_modules/micromark-extension-mdx-md": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^1.0.0"
@@ -9734,6 +9984,7 @@
     },
     "node_modules/micromark-extension-mdxjs": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.0.0",
@@ -9752,6 +10003,7 @@
     },
     "node_modules/micromark-extension-mdxjs-esm": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -9771,6 +10023,7 @@
     },
     "node_modules/micromark-factory-destination": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9790,6 +10043,7 @@
     },
     "node_modules/micromark-factory-label": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9810,6 +10064,7 @@
     },
     "node_modules/micromark-factory-mdx-expression": {
       "version": "1.0.9",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9834,6 +10089,7 @@
     },
     "node_modules/micromark-factory-space": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9852,6 +10108,7 @@
     },
     "node_modules/micromark-factory-title": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9872,6 +10129,7 @@
     },
     "node_modules/micromark-factory-whitespace": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9892,6 +10150,7 @@
     },
     "node_modules/micromark-util-character": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9910,6 +10169,7 @@
     },
     "node_modules/micromark-util-chunked": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9927,6 +10187,7 @@
     },
     "node_modules/micromark-util-classify-character": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9946,6 +10207,7 @@
     },
     "node_modules/micromark-util-combine-extensions": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9964,6 +10226,7 @@
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9981,6 +10244,7 @@
     },
     "node_modules/micromark-util-decode-string": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10001,6 +10265,7 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10015,6 +10280,7 @@
     },
     "node_modules/micromark-util-events-to-acorn": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10039,6 +10305,7 @@
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10053,6 +10320,7 @@
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10070,6 +10338,7 @@
     },
     "node_modules/micromark-util-resolve-all": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10087,6 +10356,7 @@
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10106,6 +10376,7 @@
     },
     "node_modules/micromark-util-subtokenize": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10126,6 +10397,7 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10140,6 +10412,7 @@
     },
     "node_modules/micromark-util-types": {
       "version": "1.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10207,6 +10480,7 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -10240,6 +10514,7 @@
     },
     "node_modules/minipass": {
       "version": "7.0.4",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10247,6 +10522,7 @@
     },
     "node_modules/minipass-collect": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -10257,6 +10533,7 @@
     },
     "node_modules/minipass-collect/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -10267,10 +10544,12 @@
     },
     "node_modules/minipass-collect/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -10281,6 +10560,7 @@
     },
     "node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -10291,10 +10571,12 @@
     },
     "node_modules/minipass-flush/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -10305,6 +10587,7 @@
     },
     "node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -10315,10 +10598,12 @@
     },
     "node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -10330,6 +10615,7 @@
     },
     "node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -10340,10 +10626,12 @@
     },
     "node_modules/minizlib/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -10354,6 +10642,7 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mlly": {
@@ -10403,6 +10692,7 @@
     },
     "node_modules/mri": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10478,6 +10768,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -10496,10 +10787,12 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.13",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-package-data": {
       "version": "5.0.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^6.0.0",
@@ -10520,6 +10813,7 @@
     },
     "node_modules/npm-install-checks": {
       "version": "6.2.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "semver": "^7.1.1"
@@ -10530,6 +10824,7 @@
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -10537,6 +10832,7 @@
     },
     "node_modules/npm-package-arg": {
       "version": "10.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^6.0.0",
@@ -10550,6 +10846,7 @@
     },
     "node_modules/npm-pick-manifest": {
       "version": "8.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "npm-install-checks": "^6.0.0",
@@ -10947,6 +11244,7 @@
     },
     "node_modules/ora": {
       "version": "5.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
@@ -10968,6 +11266,7 @@
     },
     "node_modules/ora/node_modules/cli-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -10978,6 +11277,7 @@
     },
     "node_modules/ora/node_modules/restore-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -10997,6 +11297,7 @@
     },
     "node_modules/outdent": {
       "version": "0.8.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/p-event": {
@@ -11127,6 +11428,7 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "aggregate-error": "^3.0.0"
@@ -11160,6 +11462,7 @@
     },
     "node_modules/pako": {
       "version": "0.2.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/parent-module": {
@@ -11174,6 +11477,7 @@
     },
     "node_modules/parse-entities": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -11214,6 +11518,7 @@
     },
     "node_modules/parse-ms": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11253,6 +11558,7 @@
     },
     "node_modules/path-scurry": {
       "version": "1.10.1",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^9.1.1 || ^10.0.0",
@@ -11267,6 +11573,7 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "14 || >=16.14"
@@ -11296,6 +11603,7 @@
     },
     "node_modules/peek-stream": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11305,10 +11613,12 @@
     },
     "node_modules/peek-stream/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/peek-stream/node_modules/readable-stream": {
       "version": "2.3.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -11322,6 +11632,7 @@
     },
     "node_modules/peek-stream/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -11329,6 +11640,7 @@
     },
     "node_modules/peek-stream/node_modules/through2": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -11337,6 +11649,7 @@
     },
     "node_modules/periscopic": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -11360,6 +11673,7 @@
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "pidtree": "bin/pidtree.js"
@@ -11421,6 +11735,7 @@
     },
     "node_modules/postcss-discard-duplicates": {
       "version": "5.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -11465,6 +11780,7 @@
     },
     "node_modules/postcss-load-config": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lilconfig": "^2.0.5",
@@ -11492,6 +11808,7 @@
     },
     "node_modules/postcss-modules": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "generic-names": "^4.0.0",
@@ -11509,6 +11826,7 @@
     },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -11519,6 +11837,7 @@
     },
     "node_modules/postcss-modules-local-by-default": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.0.0",
@@ -11534,6 +11853,7 @@
     },
     "node_modules/postcss-modules-scope": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "postcss-selector-parser": "^6.0.4"
@@ -11547,6 +11867,7 @@
     },
     "node_modules/postcss-modules-values": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "icss-utils": "^5.0.0"
@@ -11578,6 +11899,7 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11589,6 +11911,7 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -11666,6 +11989,7 @@
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^2.1.0"
@@ -11679,6 +12003,7 @@
     },
     "node_modules/proc-log": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11686,14 +12011,17 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
@@ -11720,6 +12048,7 @@
     },
     "node_modules/property-information": {
       "version": "6.3.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11739,6 +12068,7 @@
     },
     "node_modules/pump": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -11747,6 +12077,7 @@
     },
     "node_modules/pumpify": {
       "version": "1.5.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "duplexify": "^3.6.0",
@@ -11855,6 +12186,7 @@
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12125,6 +12457,7 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
@@ -12154,6 +12487,7 @@
     },
     "node_modules/remark-frontmatter": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -12168,6 +12502,7 @@
     },
     "node_modules/remark-mdx": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdast-util-mdx": "^2.0.0",
@@ -12180,6 +12515,7 @@
     },
     "node_modules/remark-mdx-frontmatter": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "estree-util-is-identifier-name": "^1.0.0",
@@ -12193,6 +12529,7 @@
     },
     "node_modules/remark-mdx-frontmatter/node_modules/estree-util-is-identifier-name": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -12201,6 +12538,7 @@
     },
     "node_modules/remark-parse": {
       "version": "10.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -12214,6 +12552,7 @@
     },
     "node_modules/remark-rehype": {
       "version": "10.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
@@ -12443,6 +12782,7 @@
     },
     "node_modules/require-like": {
       "version": "0.1.2",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -12498,6 +12838,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12536,6 +12877,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -12677,6 +13019,7 @@
     },
     "node_modules/sade": {
       "version": "1.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mri": "^1.1.0"
@@ -12934,6 +13277,7 @@
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -12942,6 +13286,7 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -12974,6 +13319,7 @@
     },
     "node_modules/ssri": {
       "version": "10.0.5",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
@@ -13054,6 +13400,7 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-slice": {
@@ -13095,6 +13442,7 @@
     },
     "node_modules/string-hash": {
       "version": "1.1.3",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/string-width": {
@@ -13112,6 +13460,7 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13124,10 +13473,12 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13236,6 +13587,7 @@
     },
     "node_modules/stringify-entities": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -13259,6 +13611,7 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13314,6 +13667,7 @@
     },
     "node_modules/style-to-object": {
       "version": "0.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.1.1"
@@ -13477,6 +13831,7 @@
     },
     "node_modules/tar": {
       "version": "6.2.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -13492,6 +13847,7 @@
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -13502,10 +13858,12 @@
     },
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/tar-fs/node_modules/pump": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -13514,6 +13872,7 @@
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -13528,6 +13887,7 @@
     },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -13538,6 +13898,7 @@
     },
     "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -13548,6 +13909,7 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -13555,6 +13917,7 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/test-exclude": {
@@ -13698,6 +14061,7 @@
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -13722,14 +14086,17 @@
     },
     "node_modules/toml": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -13746,6 +14113,7 @@
     },
     "node_modules/trough": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -13769,7 +14137,7 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -13811,11 +14179,12 @@
     },
     "node_modules/ts-node/node_modules/arg": {
       "version": "4.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
@@ -14083,6 +14452,7 @@
     },
     "node_modules/unified": {
       "version": "10.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14100,6 +14470,7 @@
     },
     "node_modules/unified/node_modules/is-plain-obj": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14110,6 +14481,7 @@
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^4.0.0"
@@ -14120,6 +14492,7 @@
     },
     "node_modules/unique-slug": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -14130,6 +14503,7 @@
     },
     "node_modules/unist-util-generated": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -14138,6 +14512,7 @@
     },
     "node_modules/unist-util-is": {
       "version": "5.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0"
@@ -14149,6 +14524,7 @@
     },
     "node_modules/unist-util-position": {
       "version": "4.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0"
@@ -14160,6 +14536,7 @@
     },
     "node_modules/unist-util-position-from-estree": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0"
@@ -14171,6 +14548,7 @@
     },
     "node_modules/unist-util-remove-position": {
       "version": "4.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14183,6 +14561,7 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0"
@@ -14194,6 +14573,7 @@
     },
     "node_modules/unist-util-visit": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14207,6 +14587,7 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "5.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14240,6 +14621,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14297,6 +14679,7 @@
     },
     "node_modules/uvu": {
       "version": "0.5.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0",
@@ -14313,6 +14696,7 @@
     },
     "node_modules/uvu/node_modules/diff": {
       "version": "5.1.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -14320,7 +14704,7 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -14338,6 +14722,7 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -14346,6 +14731,7 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "builtins": "^5.0.0"
@@ -14363,6 +14749,7 @@
     },
     "node_modules/vfile": {
       "version": "5.3.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14377,6 +14764,7 @@
     },
     "node_modules/vfile-message": {
       "version": "3.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14442,6 +14830,7 @@
     },
     "node_modules/vite-node": {
       "version": "0.28.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -14465,6 +14854,7 @@
     },
     "node_modules/vite-node/node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -14617,6 +15007,7 @@
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
@@ -14641,10 +15032,12 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -14653,6 +15046,7 @@
     },
     "node_modules/which": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -14750,6 +15144,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -14766,6 +15161,7 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -14781,10 +15177,12 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14792,6 +15190,7 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -14804,6 +15203,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14814,6 +15214,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14824,6 +15225,7 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -14839,6 +15241,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -14856,6 +15259,7 @@
     },
     "node_modules/ws": {
       "version": "7.5.9",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -14875,6 +15279,7 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -14890,10 +15295,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.3.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 14"
@@ -14960,7 +15367,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14978,6 +15385,7 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -15608,7 +16016,6 @@
       "dependencies": {
         "@remix-pwa/cache": "^2.0.10",
         "@remix-pwa/strategy": "^2.1.9-dev.1",
-        "@remix-pwa/sw": "2.1.11-dev.2",
         "@remix-pwa/sync": "^2.0.1",
         "@remix-pwa/worker-runtime": "^2.0.6",
         "@remix-run/css-bundle": "^2.0.1",
@@ -15636,26 +16043,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "playground/node_modules/@remix-pwa/sw": {
-      "version": "2.1.11-dev.2",
-      "resolved": "https://registry.npmjs.org/@remix-pwa/sw/-/sw-2.1.11-dev.2.tgz",
-      "integrity": "sha512-myh49ZPYNk0rg8ErLAjPJ4BauLLUB5Bkve8nRFHIIkVc7SpkNdVJHb/QRvmcPSnc6uB0IL8KVj/qwTycLYZI3w==",
-      "dependencies": {
-        "@remix-run/server-runtime": "^2.0.1",
-        "idb": "^7.1.1",
-        "tiny-invariant": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@remix-pwa/cache": "^2.0.12-dev.1",
-        "@remix-run/dev": "^1.15.0 || ^2.0.0",
-        "@remix-run/react": "^1.15.0 || ^2.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3715,6 +3715,131 @@
         "typescript": ">=4"
       }
     },
+    "node_modules/cp-file": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-10.0.0.tgz",
+      "integrity": "sha512-vy2Vi1r2epK5WqxOLnskeKeZkdZvTKfFZQCplE3XWsP+SUJyd5XAUFC9lFgTjjXJF2GMne/UML14iEmkAaDfFg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.10",
+        "nested-error-stacks": "^2.1.1",
+        "p-event": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cpy": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cpy/-/cpy-10.1.0.tgz",
+      "integrity": "sha512-VC2Gs20JcTyeQob6UViBLnyP0bYHkBh6EiKzot9vi2DmeGlFT9Wd7VG3NBrkNx/jYvFBeyDOMMHdHQhbtKLgHQ==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^3.0.0",
+        "cp-file": "^10.0.0",
+        "globby": "^13.1.4",
+        "junk": "^4.0.1",
+        "micromatch": "^4.0.5",
+        "nested-error-stacks": "^2.1.1",
+        "p-filter": "^3.0.0",
+        "p-map": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cpy-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cpy-cli/-/cpy-cli-5.0.0.tgz",
+      "integrity": "sha512-fb+DZYbL9KHc0BC4NYqGRrDIJZPXUmjjtqdw4XRRg8iV8dIfghUX/WiL+q4/B/KFTy3sK6jsbUhBaz0/Hxg7IQ==",
+      "dev": true,
+      "dependencies": {
+        "cpy": "^10.1.0",
+        "meow": "^12.0.1"
+      },
+      "bin": {
+        "cpy": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cpy-cli/node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cpy/node_modules/arrify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cpy/node_modules/globby": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cpy/node_modules/p-map": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cpy/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "devOptional": true,
@@ -7377,6 +7502,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/junk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.3",
       "license": "MIT",
@@ -9068,6 +9205,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nested-error-stacks": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz",
+      "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==",
+      "dev": true
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "dev": true,
@@ -9596,6 +9739,106 @@
       "version": "0.8.0",
       "license": "MIT"
     },
+    "node_modules/p-event": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-5.0.1.tgz",
+      "integrity": "sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==",
+      "dev": true,
+      "dependencies": {
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-3.0.0.tgz",
+      "integrity": "sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==",
+      "dev": true,
+      "dependencies": {
+        "p-map": "^5.1.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter/node_modules/aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter/node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter/node_modules/p-map": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "license": "MIT",
@@ -9630,6 +9873,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10750,28 +11005,6 @@
           "optional": true
         },
         "@remix-run/dev": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/remix-pwa/node_modules/@remix-pwa/worker-runtime": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@remix-pwa/worker-runtime/-/worker-runtime-2.0.7.tgz",
-      "integrity": "sha512-V1Vz/594AbPP84z60XWTEl7wmsGkzK34PqlCBihkQMj+lSakpE2u3QS25O1tDr1qcw2/54soPAuvmShjljbFFQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@remix-run/server-runtime": "^1.19.2 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/server-runtime": {
           "optional": true
         }
       }
@@ -13462,7 +13695,7 @@
     },
     "packages/dev": {
       "name": "@remix-pwa/dev",
-      "version": "2.0.30-dev.3",
+      "version": "2.0.31",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",
@@ -13477,9 +13710,10 @@
       "devDependencies": {
         "@remix-pwa/eslint-config": "^0.0.0",
         "@remix-pwa/lint-staged-config": "^0.0.0",
-        "@remix-pwa/worker-runtime": "^2.0.7-dev.3",
+        "@remix-pwa/worker-runtime": "^2.0.8",
         "@remix-run/dev": "^2.0.1",
         "@types/fs-extra": "^11.0.2",
+        "cpy-cli": "^5.0.0",
         "cross-env": "^7.0.3",
         "rimraf": "^5.0.5"
       },
@@ -13487,7 +13721,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-pwa/worker-runtime": "^2.0.7-dev.3",
+        "@remix-pwa/worker-runtime": "^2.0.8",
         "@remix-run/dev": "^1.15.0 || ^2.0.0"
       },
       "peerDependenciesMeta": {
@@ -13495,26 +13729,6 @@
           "optional": true
         },
         "@remix-run/dev": {
-          "optional": true
-        }
-      }
-    },
-    "packages/dev/node_modules/@remix-pwa/worker-runtime": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@remix-pwa/worker-runtime/-/worker-runtime-2.0.7.tgz",
-      "integrity": "sha512-V1Vz/594AbPP84z60XWTEl7wmsGkzK34PqlCBihkQMj+lSakpE2u3QS25O1tDr1qcw2/54soPAuvmShjljbFFQ==",
-      "dev": true,
-      "dependencies": {
-        "@remix-run/router": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@remix-run/server-runtime": "^1.19.2 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/server-runtime": {
           "optional": true
         }
       }
@@ -13937,7 +14151,7 @@
     },
     "packages/sw": {
       "name": "@remix-pwa/sw",
-      "version": "2.1.11-dev.3",
+      "version": "2.1.12",
       "license": "MIT",
       "dependencies": {
         "@remix-run/server-runtime": "^2.0.1",
@@ -13945,7 +14159,7 @@
         "tiny-invariant": "^1.3.1"
       },
       "devDependencies": {
-        "@remix-pwa/cache": "^2.0.12-dev.1",
+        "@remix-pwa/cache": "^2.0.12",
         "@remix-pwa/eslint-config": "^0.0.0",
         "@remix-pwa/lint-staged-config": "^0.0.0",
         "@remix-run/dev": "^2.0.1",
@@ -13958,7 +14172,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@remix-pwa/cache": "^2.0.12-dev.1",
+        "@remix-pwa/cache": "^2.0.12",
         "@remix-run/dev": "^1.15.0 || ^2.0.0",
         "@remix-run/react": "^1.15.0 || ^2.0.0",
         "react": "^18.2.0",
@@ -14042,7 +14256,7 @@
     },
     "packages/worker-runtime": {
       "name": "@remix-pwa/worker-runtime",
-      "version": "2.0.7-dev.2",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "^1.9.0"
@@ -14123,47 +14337,6 @@
         "@remix-run/react": "^1.15.0 || ^2.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
-      }
-    },
-    "playground/node_modules/@remix-pwa/worker-runtime": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remix-pwa/worker-runtime/-/worker-runtime-2.0.6.tgz",
-      "integrity": "sha512-MfE0QzbqBYVMaZ2kMFl+bq8nf3D0diCn49g4O/zUxjy9eHTCei5Ix4d/RAGxG7SKHNY0ud/ooEmGIouaVUNZtA==",
-      "dependencies": {
-        "@remix-run/router": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@remix-run/server-runtime": "^1.19.2 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/server-runtime": {
-          "optional": true
-        }
-      }
-    },
-    "playground/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4018,30 +4018,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-browser": {
-      "name": "buffer",
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "license": "MIT"
@@ -14081,6 +14057,17 @@
       "version": "1.3.1",
       "license": "MIT"
     },
+    "node_modules/uint8array-extras": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-0.5.0.tgz",
+      "integrity": "sha512-CKAKa+/rjCblsuGrcmIJLluHcZMYKcMwgdhAZZEnSplFFGCuGKF6e2L+CeVXK0zX5rYyerrqG2dnHIANm3i9qA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "license": "MIT",
@@ -15002,8 +14989,8 @@
       "version": "2.0.12",
       "license": "MIT",
       "dependencies": {
-        "buffer-browser": "npm:buffer@^6.0.3",
-        "cachified": "^3.5.4"
+        "cachified": "^3.5.4",
+        "uint8array-extras": "^0.5.0"
       },
       "devDependencies": {
         "@remix-pwa/eslint-config": "^0.0.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -32,7 +32,7 @@
     "@remix-pwa/lint-staged-config": "^0.0.0"
   },
   "dependencies": {
-    "buffer": "^6.0.3",
+    "buffer-browser": "npm:buffer@^6.0.3",
     "cachified": "^3.5.4"
   },
   "keywords": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -32,7 +32,7 @@
     "@remix-pwa/lint-staged-config": "^0.0.0"
   },
   "dependencies": {
-    "buffer-browser": "npm:buffer@^6.0.3",
+    "uint8array-extras": "^0.5.0",
     "cachified": "^3.5.4"
   },
   "keywords": [

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -1,4 +1,4 @@
-import * as B from 'buffer/';
+import * as B from 'buffer-browser';
 
 import { mergeHeaders, omit } from './utils.js';
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -1,4 +1,4 @@
-import * as B from 'buffer-browser';
+import { base64ToUint8Array, uint8ArrayToString } from 'uint8array-extras';
 
 import { mergeHeaders, omit } from './utils.js';
 
@@ -221,8 +221,7 @@ export class RemixCache implements CustomCache {
       responseOptions.body = value as string;
     } else {
       // Binary or other response types
-      const buffer = B.Buffer.from(value as string, 'base64');
-      responseOptions.body = new Uint8Array(buffer);
+      responseOptions.body = base64ToUint8Array(value as string);
     }
 
     if (!deleted) {
@@ -350,7 +349,7 @@ export class RemixCache implements CustomCache {
       data = await response.clone().text();
     } else {
       const buffer = await response.clone().arrayBuffer();
-      data = B.Buffer.from(buffer).toString('base64');
+      data = uint8ArrayToString(new Uint8Array(buffer));
     }
 
     // Temporary. Actually slows this process down by an average of 2ms. Not good enough.

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -20,7 +20,7 @@
     "build": "rimraf ./dist && tsc && npm run copy",
     "prepublishOnly": "npm run build",
     "compile": "tsc && node ./build.cjs",
-    "copy": "cp -r cli/templates dist/cli/templates",
+    "copy": "cpy cli/templates dist",
     "format": "prettier --write \"cli/**/*.ts\" \"compiler/**/*.ts\"",
     "lint": "TIMING=1 eslint --fix cli/ compiler/",
     "prepublish": "npm run build",
@@ -59,6 +59,7 @@
     "@remix-pwa/eslint-config": "^0.0.0",
     "@remix-pwa/lint-staged-config": "^0.0.0",
     "@types/fs-extra": "^11.0.2",
+    "cpy-cli": "^5.0.0",
     "cross-env": "^7.0.3",
     "rimraf": "^5.0.5"
   }

--- a/packages/sw/src/private/logger.ts
+++ b/packages/sw/src/private/logger.ts
@@ -1,35 +1,35 @@
 /* eslint-disable no-var */
 // these only become globals with var
 declare global {
-    /**
-     * Disable all logs from displaying in the console.
-     *
-     * @default false
-     */
+  /**
+   * Disable all logs from displaying in the console.
+   *
+   * @default false
+   */
   var __DISABLE_PWA_DEV_LOGS: boolean;
-    /**
-     * Disable debug logs from displaying in the console.
-     *
-     * @default false
-     */
+  /**
+   * Disable debug logs from displaying in the console.
+   *
+   * @default false
+   */
   var __DISABLE_PWA_DEBUG_LOGS: boolean;
-    /**
-     * Disable info logs from displaying in the console.
-     *
-     * @default false
-     */
+  /**
+   * Disable info logs from displaying in the console.
+   *
+   * @default false
+   */
   var __DISABLE_PWA_INFO_LOGS: boolean;
-    /**
-     * Disable warning logs from displaying in the console.
-     *
-     * @default false
-     */
+  /**
+   * Disable warning logs from displaying in the console.
+   *
+   * @default false
+   */
   var __DISABLE_PWA_WARN_LOGS: boolean;
-    /**
-     * Disable error logs from displaying in the console.
-     *
-     * @default false
-     */
+  /**
+   * Disable error logs from displaying in the console.
+   *
+   * @default false
+   */
   var __DISABLE_PWA_ERROR_LOGS: boolean;
 }
 /* eslint-enable no-var */
@@ -86,6 +86,8 @@ export const logger = (
         let inGroup = false;
 
         const print = function (method: LoggerMethods, args: any[]) {
+          const self = typeof globalThis.self !== 'undefined' ? globalThis.self : globalThis;
+
           // Conditionals to handle various log levels.
           if (self.__DISABLE_PWA_DEV_LOGS) {
             return;

--- a/packages/sw/src/private/logger.ts
+++ b/packages/sw/src/private/logger.ts
@@ -1,72 +1,38 @@
+/* eslint-disable no-var */
+// these only become globals with var
 declare global {
-  interface WorkerGlobalScope {
     /**
      * Disable all logs from displaying in the console.
      *
      * @default false
      */
-    __DISABLE_PWA_DEV_LOGS: boolean;
+  var __DISABLE_PWA_DEV_LOGS: boolean;
     /**
      * Disable debug logs from displaying in the console.
      *
      * @default false
      */
-    __DISABLE_PWA_DEBUG_LOGS: boolean;
+  var __DISABLE_PWA_DEBUG_LOGS: boolean;
     /**
      * Disable info logs from displaying in the console.
      *
      * @default false
      */
-    __DISABLE_PWA_INFO_LOGS: boolean;
+  var __DISABLE_PWA_INFO_LOGS: boolean;
     /**
      * Disable warning logs from displaying in the console.
      *
      * @default false
      */
-    __DISABLE_PWA_WARN_LOGS: boolean;
+  var __DISABLE_PWA_WARN_LOGS: boolean;
     /**
      * Disable error logs from displaying in the console.
      *
      * @default false
      */
-    __DISABLE_PWA_ERROR_LOGS: boolean;
-  }
-
-  // You might want to expantiate on this. In order to disable
-  // logger in the main thread too.
-  interface Window {
-    /**
-     * Disable all logs from displaying in the console.
-     *
-     * @default false
-     */
-    __DISABLE_PWA_DEV_LOGS: boolean;
-    /**
-     * Disable debug logs from displaying in the console.
-     *
-     * @default false
-     */
-    __DISABLE_PWA_DEBUG_LOGS: boolean;
-    /**
-     * Disable info logs from displaying in the console.
-     *
-     * @default false
-     */
-    __DISABLE_PWA_INFO_LOGS: boolean;
-    /**
-     * Disable warning logs from displaying in the console.
-     *
-     * @default false
-     */
-    __DISABLE_PWA_WARN_LOGS: boolean;
-    /**
-     * Disable error logs from displaying in the console.
-     *
-     * @default false
-     */
-    __DISABLE_PWA_ERROR_LOGS: boolean;
-  }
+  var __DISABLE_PWA_ERROR_LOGS: boolean;
 }
+/* eslint-enable no-var */
 
 export type LoggerMethods = 'debug' | 'info' | 'log' | 'warn' | 'error' | 'groupCollapsed' | 'groupEnd';
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@remix-pwa/cache": "^2.0.10",
     "@remix-pwa/strategy": "^2.1.9-dev.1",
-    "@remix-pwa/sw": "2.1.11-dev.2",
     "@remix-pwa/sync": "^2.0.1",
     "@remix-pwa/worker-runtime": "^2.0.6",
     "@remix-run/css-bundle": "^2.0.1",

--- a/playground/package.json
+++ b/playground/package.json
@@ -12,12 +12,12 @@
   "sideEffects": false,
   "private": true,
   "scripts": {
-    "build:worker": "node ./sw.ts build",
+    "build:worker": "tsx ../packages/dev/index.ts build",
     "buildt": "run-p build:*",
     "dev": "run-p dev:*",
     "start": "remix-serve ./build/index.js",
     "typecheck": "tsc",
-    "dev:worker": "ts-node ./sw.ts dev",
+    "dev:worker": "tsx ../packages/dev/index.ts dev",
     "dev:remix": "remix dev",
     "build:remix": "remix build"
   },
@@ -47,7 +47,7 @@
     "npm-run-all": "^4.1.5",
     "remix-pwa": "^3.0.17",
     "tailwindcss": "^3.3.3",
-    "ts-node": "^10.9.1",
+    "tsx": "^3.14.0",
     "typescript": "^5.2.2"
   },
   "engines": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@remix-pwa/playground",
+  "type": "module",
   "version": "0.0.0",
   "description": "A Playground for Remix PWA 3.0",
   "repository": {

--- a/playground/public/entry.worker.js
+++ b/playground/public/entry.worker.js
@@ -217,1715 +217,20 @@ var require_ieee754 = __commonJS({
   }
 });
 
-// node_modules/buffer/index.js
-var require_buffer = __commonJS({
-  "node_modules/buffer/index.js"(exports) {
-    "use strict";
-    var base64 = require_base64_js();
-    var ieee754 = require_ieee754();
-    var customInspectSymbol = typeof Symbol === "function" && typeof Symbol["for"] === "function" ? Symbol["for"]("nodejs.util.inspect.custom") : null;
-    exports.Buffer = Buffer4;
-    exports.SlowBuffer = SlowBuffer;
-    exports.INSPECT_MAX_BYTES = 50;
-    var K_MAX_LENGTH = 2147483647;
-    exports.kMaxLength = K_MAX_LENGTH;
-    Buffer4.TYPED_ARRAY_SUPPORT = typedArraySupport();
-    if (!Buffer4.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
-      console.error(
-        "This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support."
-      );
-    }
-    function typedArraySupport() {
-      try {
-        const arr = new Uint8Array(1);
-        const proto = { foo: function() {
-          return 42;
-        } };
-        Object.setPrototypeOf(proto, Uint8Array.prototype);
-        Object.setPrototypeOf(arr, proto);
-        return arr.foo() === 42;
-      } catch (e) {
-        return false;
-      }
-    }
-    Object.defineProperty(Buffer4.prototype, "parent", {
-      enumerable: true,
-      get: function() {
-        if (!Buffer4.isBuffer(this))
-          return void 0;
-        return this.buffer;
-      }
-    });
-    Object.defineProperty(Buffer4.prototype, "offset", {
-      enumerable: true,
-      get: function() {
-        if (!Buffer4.isBuffer(this))
-          return void 0;
-        return this.byteOffset;
-      }
-    });
-    function createBuffer(length) {
-      if (length > K_MAX_LENGTH) {
-        throw new RangeError('The value "' + length + '" is invalid for option "size"');
-      }
-      const buf = new Uint8Array(length);
-      Object.setPrototypeOf(buf, Buffer4.prototype);
-      return buf;
-    }
-    function Buffer4(arg, encodingOrOffset, length) {
-      if (typeof arg === "number") {
-        if (typeof encodingOrOffset === "string") {
-          throw new TypeError(
-            'The "string" argument must be of type string. Received type number'
-          );
-        }
-        return allocUnsafe(arg);
-      }
-      return from(arg, encodingOrOffset, length);
-    }
-    Buffer4.poolSize = 8192;
-    function from(value, encodingOrOffset, length) {
-      if (typeof value === "string") {
-        return fromString(value, encodingOrOffset);
-      }
-      if (ArrayBuffer.isView(value)) {
-        return fromArrayView(value);
-      }
-      if (value == null) {
-        throw new TypeError(
-          "The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value
-        );
-      }
-      if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer)) {
-        return fromArrayBuffer(value, encodingOrOffset, length);
-      }
-      if (typeof SharedArrayBuffer !== "undefined" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer))) {
-        return fromArrayBuffer(value, encodingOrOffset, length);
-      }
-      if (typeof value === "number") {
-        throw new TypeError(
-          'The "value" argument must not be of type number. Received type number'
-        );
-      }
-      const valueOf = value.valueOf && value.valueOf();
-      if (valueOf != null && valueOf !== value) {
-        return Buffer4.from(valueOf, encodingOrOffset, length);
-      }
-      const b2 = fromObject(value);
-      if (b2)
-        return b2;
-      if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function") {
-        return Buffer4.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
-      }
-      throw new TypeError(
-        "The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value
-      );
-    }
-    Buffer4.from = function(value, encodingOrOffset, length) {
-      return from(value, encodingOrOffset, length);
-    };
-    Object.setPrototypeOf(Buffer4.prototype, Uint8Array.prototype);
-    Object.setPrototypeOf(Buffer4, Uint8Array);
-    function assertSize(size) {
-      if (typeof size !== "number") {
-        throw new TypeError('"size" argument must be of type number');
-      } else if (size < 0) {
-        throw new RangeError('The value "' + size + '" is invalid for option "size"');
-      }
-    }
-    function alloc(size, fill, encoding) {
-      assertSize(size);
-      if (size <= 0) {
-        return createBuffer(size);
-      }
-      if (fill !== void 0) {
-        return typeof encoding === "string" ? createBuffer(size).fill(fill, encoding) : createBuffer(size).fill(fill);
-      }
-      return createBuffer(size);
-    }
-    Buffer4.alloc = function(size, fill, encoding) {
-      return alloc(size, fill, encoding);
-    };
-    function allocUnsafe(size) {
-      assertSize(size);
-      return createBuffer(size < 0 ? 0 : checked(size) | 0);
-    }
-    Buffer4.allocUnsafe = function(size) {
-      return allocUnsafe(size);
-    };
-    Buffer4.allocUnsafeSlow = function(size) {
-      return allocUnsafe(size);
-    };
-    function fromString(string, encoding) {
-      if (typeof encoding !== "string" || encoding === "") {
-        encoding = "utf8";
-      }
-      if (!Buffer4.isEncoding(encoding)) {
-        throw new TypeError("Unknown encoding: " + encoding);
-      }
-      const length = byteLength(string, encoding) | 0;
-      let buf = createBuffer(length);
-      const actual = buf.write(string, encoding);
-      if (actual !== length) {
-        buf = buf.slice(0, actual);
-      }
-      return buf;
-    }
-    function fromArrayLike(array) {
-      const length = array.length < 0 ? 0 : checked(array.length) | 0;
-      const buf = createBuffer(length);
-      for (let i = 0; i < length; i += 1) {
-        buf[i] = array[i] & 255;
-      }
-      return buf;
-    }
-    function fromArrayView(arrayView) {
-      if (isInstance(arrayView, Uint8Array)) {
-        const copy = new Uint8Array(arrayView);
-        return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength);
-      }
-      return fromArrayLike(arrayView);
-    }
-    function fromArrayBuffer(array, byteOffset, length) {
-      if (byteOffset < 0 || array.byteLength < byteOffset) {
-        throw new RangeError('"offset" is outside of buffer bounds');
-      }
-      if (array.byteLength < byteOffset + (length || 0)) {
-        throw new RangeError('"length" is outside of buffer bounds');
-      }
-      let buf;
-      if (byteOffset === void 0 && length === void 0) {
-        buf = new Uint8Array(array);
-      } else if (length === void 0) {
-        buf = new Uint8Array(array, byteOffset);
-      } else {
-        buf = new Uint8Array(array, byteOffset, length);
-      }
-      Object.setPrototypeOf(buf, Buffer4.prototype);
-      return buf;
-    }
-    function fromObject(obj) {
-      if (Buffer4.isBuffer(obj)) {
-        const len = checked(obj.length) | 0;
-        const buf = createBuffer(len);
-        if (buf.length === 0) {
-          return buf;
-        }
-        obj.copy(buf, 0, 0, len);
-        return buf;
-      }
-      if (obj.length !== void 0) {
-        if (typeof obj.length !== "number" || numberIsNaN(obj.length)) {
-          return createBuffer(0);
-        }
-        return fromArrayLike(obj);
-      }
-      if (obj.type === "Buffer" && Array.isArray(obj.data)) {
-        return fromArrayLike(obj.data);
-      }
-    }
-    function checked(length) {
-      if (length >= K_MAX_LENGTH) {
-        throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + K_MAX_LENGTH.toString(16) + " bytes");
-      }
-      return length | 0;
-    }
-    function SlowBuffer(length) {
-      if (+length != length) {
-        length = 0;
-      }
-      return Buffer4.alloc(+length);
-    }
-    Buffer4.isBuffer = function isBuffer(b2) {
-      return b2 != null && b2._isBuffer === true && b2 !== Buffer4.prototype;
-    };
-    Buffer4.compare = function compare(a, b2) {
-      if (isInstance(a, Uint8Array))
-        a = Buffer4.from(a, a.offset, a.byteLength);
-      if (isInstance(b2, Uint8Array))
-        b2 = Buffer4.from(b2, b2.offset, b2.byteLength);
-      if (!Buffer4.isBuffer(a) || !Buffer4.isBuffer(b2)) {
-        throw new TypeError(
-          'The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array'
-        );
-      }
-      if (a === b2)
-        return 0;
-      let x = a.length;
-      let y2 = b2.length;
-      for (let i = 0, len = Math.min(x, y2); i < len; ++i) {
-        if (a[i] !== b2[i]) {
-          x = a[i];
-          y2 = b2[i];
-          break;
-        }
-      }
-      if (x < y2)
-        return -1;
-      if (y2 < x)
-        return 1;
-      return 0;
-    };
-    Buffer4.isEncoding = function isEncoding(encoding) {
-      switch (String(encoding).toLowerCase()) {
-        case "hex":
-        case "utf8":
-        case "utf-8":
-        case "ascii":
-        case "latin1":
-        case "binary":
-        case "base64":
-        case "ucs2":
-        case "ucs-2":
-        case "utf16le":
-        case "utf-16le":
-          return true;
-        default:
-          return false;
-      }
-    };
-    Buffer4.concat = function concat2(list, length) {
-      if (!Array.isArray(list)) {
-        throw new TypeError('"list" argument must be an Array of Buffers');
-      }
-      if (list.length === 0) {
-        return Buffer4.alloc(0);
-      }
-      let i;
-      if (length === void 0) {
-        length = 0;
-        for (i = 0; i < list.length; ++i) {
-          length += list[i].length;
-        }
-      }
-      const buffer = Buffer4.allocUnsafe(length);
-      let pos = 0;
-      for (i = 0; i < list.length; ++i) {
-        let buf = list[i];
-        if (isInstance(buf, Uint8Array)) {
-          if (pos + buf.length > buffer.length) {
-            if (!Buffer4.isBuffer(buf))
-              buf = Buffer4.from(buf);
-            buf.copy(buffer, pos);
-          } else {
-            Uint8Array.prototype.set.call(
-              buffer,
-              buf,
-              pos
-            );
-          }
-        } else if (!Buffer4.isBuffer(buf)) {
-          throw new TypeError('"list" argument must be an Array of Buffers');
-        } else {
-          buf.copy(buffer, pos);
-        }
-        pos += buf.length;
-      }
-      return buffer;
-    };
-    function byteLength(string, encoding) {
-      if (Buffer4.isBuffer(string)) {
-        return string.length;
-      }
-      if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
-        return string.byteLength;
-      }
-      if (typeof string !== "string") {
-        throw new TypeError(
-          'The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string
-        );
-      }
-      const len = string.length;
-      const mustMatch = arguments.length > 2 && arguments[2] === true;
-      if (!mustMatch && len === 0)
-        return 0;
-      let loweredCase = false;
-      for (; ; ) {
-        switch (encoding) {
-          case "ascii":
-          case "latin1":
-          case "binary":
-            return len;
-          case "utf8":
-          case "utf-8":
-            return utf8ToBytes(string).length;
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return len * 2;
-          case "hex":
-            return len >>> 1;
-          case "base64":
-            return base64ToBytes(string).length;
-          default:
-            if (loweredCase) {
-              return mustMatch ? -1 : utf8ToBytes(string).length;
-            }
-            encoding = ("" + encoding).toLowerCase();
-            loweredCase = true;
-        }
-      }
-    }
-    Buffer4.byteLength = byteLength;
-    function slowToString(encoding, start, end) {
-      let loweredCase = false;
-      if (start === void 0 || start < 0) {
-        start = 0;
-      }
-      if (start > this.length) {
-        return "";
-      }
-      if (end === void 0 || end > this.length) {
-        end = this.length;
-      }
-      if (end <= 0) {
-        return "";
-      }
-      end >>>= 0;
-      start >>>= 0;
-      if (end <= start) {
-        return "";
-      }
-      if (!encoding)
-        encoding = "utf8";
-      while (true) {
-        switch (encoding) {
-          case "hex":
-            return hexSlice(this, start, end);
-          case "utf8":
-          case "utf-8":
-            return utf8Slice(this, start, end);
-          case "ascii":
-            return asciiSlice(this, start, end);
-          case "latin1":
-          case "binary":
-            return latin1Slice(this, start, end);
-          case "base64":
-            return base64Slice(this, start, end);
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return utf16leSlice(this, start, end);
-          default:
-            if (loweredCase)
-              throw new TypeError("Unknown encoding: " + encoding);
-            encoding = (encoding + "").toLowerCase();
-            loweredCase = true;
-        }
-      }
-    }
-    Buffer4.prototype._isBuffer = true;
-    function swap(b2, n, m) {
-      const i = b2[n];
-      b2[n] = b2[m];
-      b2[m] = i;
-    }
-    Buffer4.prototype.swap16 = function swap16() {
-      const len = this.length;
-      if (len % 2 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 16-bits");
-      }
-      for (let i = 0; i < len; i += 2) {
-        swap(this, i, i + 1);
-      }
-      return this;
-    };
-    Buffer4.prototype.swap32 = function swap32() {
-      const len = this.length;
-      if (len % 4 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 32-bits");
-      }
-      for (let i = 0; i < len; i += 4) {
-        swap(this, i, i + 3);
-        swap(this, i + 1, i + 2);
-      }
-      return this;
-    };
-    Buffer4.prototype.swap64 = function swap64() {
-      const len = this.length;
-      if (len % 8 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 64-bits");
-      }
-      for (let i = 0; i < len; i += 8) {
-        swap(this, i, i + 7);
-        swap(this, i + 1, i + 6);
-        swap(this, i + 2, i + 5);
-        swap(this, i + 3, i + 4);
-      }
-      return this;
-    };
-    Buffer4.prototype.toString = function toString2() {
-      const length = this.length;
-      if (length === 0)
-        return "";
-      if (arguments.length === 0)
-        return utf8Slice(this, 0, length);
-      return slowToString.apply(this, arguments);
-    };
-    Buffer4.prototype.toLocaleString = Buffer4.prototype.toString;
-    Buffer4.prototype.equals = function equals(b2) {
-      if (!Buffer4.isBuffer(b2))
-        throw new TypeError("Argument must be a Buffer");
-      if (this === b2)
-        return true;
-      return Buffer4.compare(this, b2) === 0;
-    };
-    Buffer4.prototype.inspect = function inspect() {
-      let str = "";
-      const max = exports.INSPECT_MAX_BYTES;
-      str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim();
-      if (this.length > max)
-        str += " ... ";
-      return "<Buffer " + str + ">";
-    };
-    if (customInspectSymbol) {
-      Buffer4.prototype[customInspectSymbol] = Buffer4.prototype.inspect;
-    }
-    Buffer4.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
-      if (isInstance(target, Uint8Array)) {
-        target = Buffer4.from(target, target.offset, target.byteLength);
-      }
-      if (!Buffer4.isBuffer(target)) {
-        throw new TypeError(
-          'The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target
-        );
-      }
-      if (start === void 0) {
-        start = 0;
-      }
-      if (end === void 0) {
-        end = target ? target.length : 0;
-      }
-      if (thisStart === void 0) {
-        thisStart = 0;
-      }
-      if (thisEnd === void 0) {
-        thisEnd = this.length;
-      }
-      if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
-        throw new RangeError("out of range index");
-      }
-      if (thisStart >= thisEnd && start >= end) {
-        return 0;
-      }
-      if (thisStart >= thisEnd) {
-        return -1;
-      }
-      if (start >= end) {
-        return 1;
-      }
-      start >>>= 0;
-      end >>>= 0;
-      thisStart >>>= 0;
-      thisEnd >>>= 0;
-      if (this === target)
-        return 0;
-      let x = thisEnd - thisStart;
-      let y2 = end - start;
-      const len = Math.min(x, y2);
-      const thisCopy = this.slice(thisStart, thisEnd);
-      const targetCopy = target.slice(start, end);
-      for (let i = 0; i < len; ++i) {
-        if (thisCopy[i] !== targetCopy[i]) {
-          x = thisCopy[i];
-          y2 = targetCopy[i];
-          break;
-        }
-      }
-      if (x < y2)
-        return -1;
-      if (y2 < x)
-        return 1;
-      return 0;
-    };
-    function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
-      if (buffer.length === 0)
-        return -1;
-      if (typeof byteOffset === "string") {
-        encoding = byteOffset;
-        byteOffset = 0;
-      } else if (byteOffset > 2147483647) {
-        byteOffset = 2147483647;
-      } else if (byteOffset < -2147483648) {
-        byteOffset = -2147483648;
-      }
-      byteOffset = +byteOffset;
-      if (numberIsNaN(byteOffset)) {
-        byteOffset = dir ? 0 : buffer.length - 1;
-      }
-      if (byteOffset < 0)
-        byteOffset = buffer.length + byteOffset;
-      if (byteOffset >= buffer.length) {
-        if (dir)
-          return -1;
-        else
-          byteOffset = buffer.length - 1;
-      } else if (byteOffset < 0) {
-        if (dir)
-          byteOffset = 0;
-        else
-          return -1;
-      }
-      if (typeof val === "string") {
-        val = Buffer4.from(val, encoding);
-      }
-      if (Buffer4.isBuffer(val)) {
-        if (val.length === 0) {
-          return -1;
-        }
-        return arrayIndexOf(buffer, val, byteOffset, encoding, dir);
-      } else if (typeof val === "number") {
-        val = val & 255;
-        if (typeof Uint8Array.prototype.indexOf === "function") {
-          if (dir) {
-            return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset);
-          } else {
-            return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
-          }
-        }
-        return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
-      }
-      throw new TypeError("val must be string, number or Buffer");
-    }
-    function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
-      let indexSize = 1;
-      let arrLength = arr.length;
-      let valLength = val.length;
-      if (encoding !== void 0) {
-        encoding = String(encoding).toLowerCase();
-        if (encoding === "ucs2" || encoding === "ucs-2" || encoding === "utf16le" || encoding === "utf-16le") {
-          if (arr.length < 2 || val.length < 2) {
-            return -1;
-          }
-          indexSize = 2;
-          arrLength /= 2;
-          valLength /= 2;
-          byteOffset /= 2;
-        }
-      }
-      function read(buf, i2) {
-        if (indexSize === 1) {
-          return buf[i2];
-        } else {
-          return buf.readUInt16BE(i2 * indexSize);
-        }
-      }
-      let i;
-      if (dir) {
-        let foundIndex = -1;
-        for (i = byteOffset; i < arrLength; i++) {
-          if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
-            if (foundIndex === -1)
-              foundIndex = i;
-            if (i - foundIndex + 1 === valLength)
-              return foundIndex * indexSize;
-          } else {
-            if (foundIndex !== -1)
-              i -= i - foundIndex;
-            foundIndex = -1;
-          }
-        }
-      } else {
-        if (byteOffset + valLength > arrLength)
-          byteOffset = arrLength - valLength;
-        for (i = byteOffset; i >= 0; i--) {
-          let found = true;
-          for (let j = 0; j < valLength; j++) {
-            if (read(arr, i + j) !== read(val, j)) {
-              found = false;
-              break;
-            }
-          }
-          if (found)
-            return i;
-        }
-      }
-      return -1;
-    }
-    Buffer4.prototype.includes = function includes(val, byteOffset, encoding) {
-      return this.indexOf(val, byteOffset, encoding) !== -1;
-    };
-    Buffer4.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
-      return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
-    };
-    Buffer4.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
-      return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
-    };
-    function hexWrite(buf, string, offset, length) {
-      offset = Number(offset) || 0;
-      const remaining = buf.length - offset;
-      if (!length) {
-        length = remaining;
-      } else {
-        length = Number(length);
-        if (length > remaining) {
-          length = remaining;
-        }
-      }
-      const strLen = string.length;
-      if (length > strLen / 2) {
-        length = strLen / 2;
-      }
-      let i;
-      for (i = 0; i < length; ++i) {
-        const parsed = parseInt(string.substr(i * 2, 2), 16);
-        if (numberIsNaN(parsed))
-          return i;
-        buf[offset + i] = parsed;
-      }
-      return i;
-    }
-    function utf8Write(buf, string, offset, length) {
-      return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length);
-    }
-    function asciiWrite(buf, string, offset, length) {
-      return blitBuffer(asciiToBytes(string), buf, offset, length);
-    }
-    function base64Write(buf, string, offset, length) {
-      return blitBuffer(base64ToBytes(string), buf, offset, length);
-    }
-    function ucs2Write(buf, string, offset, length) {
-      return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
-    }
-    Buffer4.prototype.write = function write(string, offset, length, encoding) {
-      if (offset === void 0) {
-        encoding = "utf8";
-        length = this.length;
-        offset = 0;
-      } else if (length === void 0 && typeof offset === "string") {
-        encoding = offset;
-        length = this.length;
-        offset = 0;
-      } else if (isFinite(offset)) {
-        offset = offset >>> 0;
-        if (isFinite(length)) {
-          length = length >>> 0;
-          if (encoding === void 0)
-            encoding = "utf8";
-        } else {
-          encoding = length;
-          length = void 0;
-        }
-      } else {
-        throw new Error(
-          "Buffer.write(string, encoding, offset[, length]) is no longer supported"
-        );
-      }
-      const remaining = this.length - offset;
-      if (length === void 0 || length > remaining)
-        length = remaining;
-      if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length) {
-        throw new RangeError("Attempt to write outside buffer bounds");
-      }
-      if (!encoding)
-        encoding = "utf8";
-      let loweredCase = false;
-      for (; ; ) {
-        switch (encoding) {
-          case "hex":
-            return hexWrite(this, string, offset, length);
-          case "utf8":
-          case "utf-8":
-            return utf8Write(this, string, offset, length);
-          case "ascii":
-          case "latin1":
-          case "binary":
-            return asciiWrite(this, string, offset, length);
-          case "base64":
-            return base64Write(this, string, offset, length);
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return ucs2Write(this, string, offset, length);
-          default:
-            if (loweredCase)
-              throw new TypeError("Unknown encoding: " + encoding);
-            encoding = ("" + encoding).toLowerCase();
-            loweredCase = true;
-        }
-      }
-    };
-    Buffer4.prototype.toJSON = function toJSON2() {
-      return {
-        type: "Buffer",
-        data: Array.prototype.slice.call(this._arr || this, 0)
-      };
-    };
-    function base64Slice(buf, start, end) {
-      if (start === 0 && end === buf.length) {
-        return base64.fromByteArray(buf);
-      } else {
-        return base64.fromByteArray(buf.slice(start, end));
-      }
-    }
-    function utf8Slice(buf, start, end) {
-      end = Math.min(buf.length, end);
-      const res = [];
-      let i = start;
-      while (i < end) {
-        const firstByte = buf[i];
-        let codePoint = null;
-        let bytesPerSequence = firstByte > 239 ? 4 : firstByte > 223 ? 3 : firstByte > 191 ? 2 : 1;
-        if (i + bytesPerSequence <= end) {
-          let secondByte, thirdByte, fourthByte, tempCodePoint;
-          switch (bytesPerSequence) {
-            case 1:
-              if (firstByte < 128) {
-                codePoint = firstByte;
-              }
-              break;
-            case 2:
-              secondByte = buf[i + 1];
-              if ((secondByte & 192) === 128) {
-                tempCodePoint = (firstByte & 31) << 6 | secondByte & 63;
-                if (tempCodePoint > 127) {
-                  codePoint = tempCodePoint;
-                }
-              }
-              break;
-            case 3:
-              secondByte = buf[i + 1];
-              thirdByte = buf[i + 2];
-              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128) {
-                tempCodePoint = (firstByte & 15) << 12 | (secondByte & 63) << 6 | thirdByte & 63;
-                if (tempCodePoint > 2047 && (tempCodePoint < 55296 || tempCodePoint > 57343)) {
-                  codePoint = tempCodePoint;
-                }
-              }
-              break;
-            case 4:
-              secondByte = buf[i + 1];
-              thirdByte = buf[i + 2];
-              fourthByte = buf[i + 3];
-              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128 && (fourthByte & 192) === 128) {
-                tempCodePoint = (firstByte & 15) << 18 | (secondByte & 63) << 12 | (thirdByte & 63) << 6 | fourthByte & 63;
-                if (tempCodePoint > 65535 && tempCodePoint < 1114112) {
-                  codePoint = tempCodePoint;
-                }
-              }
-          }
-        }
-        if (codePoint === null) {
-          codePoint = 65533;
-          bytesPerSequence = 1;
-        } else if (codePoint > 65535) {
-          codePoint -= 65536;
-          res.push(codePoint >>> 10 & 1023 | 55296);
-          codePoint = 56320 | codePoint & 1023;
-        }
-        res.push(codePoint);
-        i += bytesPerSequence;
-      }
-      return decodeCodePointsArray(res);
-    }
-    var MAX_ARGUMENTS_LENGTH = 4096;
-    function decodeCodePointsArray(codePoints) {
-      const len = codePoints.length;
-      if (len <= MAX_ARGUMENTS_LENGTH) {
-        return String.fromCharCode.apply(String, codePoints);
-      }
-      let res = "";
-      let i = 0;
-      while (i < len) {
-        res += String.fromCharCode.apply(
-          String,
-          codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH)
-        );
-      }
-      return res;
-    }
-    function asciiSlice(buf, start, end) {
-      let ret = "";
-      end = Math.min(buf.length, end);
-      for (let i = start; i < end; ++i) {
-        ret += String.fromCharCode(buf[i] & 127);
-      }
-      return ret;
-    }
-    function latin1Slice(buf, start, end) {
-      let ret = "";
-      end = Math.min(buf.length, end);
-      for (let i = start; i < end; ++i) {
-        ret += String.fromCharCode(buf[i]);
-      }
-      return ret;
-    }
-    function hexSlice(buf, start, end) {
-      const len = buf.length;
-      if (!start || start < 0)
-        start = 0;
-      if (!end || end < 0 || end > len)
-        end = len;
-      let out = "";
-      for (let i = start; i < end; ++i) {
-        out += hexSliceLookupTable[buf[i]];
-      }
-      return out;
-    }
-    function utf16leSlice(buf, start, end) {
-      const bytes = buf.slice(start, end);
-      let res = "";
-      for (let i = 0; i < bytes.length - 1; i += 2) {
-        res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256);
-      }
-      return res;
-    }
-    Buffer4.prototype.slice = function slice2(start, end) {
-      const len = this.length;
-      start = ~~start;
-      end = end === void 0 ? len : ~~end;
-      if (start < 0) {
-        start += len;
-        if (start < 0)
-          start = 0;
-      } else if (start > len) {
-        start = len;
-      }
-      if (end < 0) {
-        end += len;
-        if (end < 0)
-          end = 0;
-      } else if (end > len) {
-        end = len;
-      }
-      if (end < start)
-        end = start;
-      const newBuf = this.subarray(start, end);
-      Object.setPrototypeOf(newBuf, Buffer4.prototype);
-      return newBuf;
-    };
-    function checkOffset(offset, ext, length) {
-      if (offset % 1 !== 0 || offset < 0)
-        throw new RangeError("offset is not uint");
-      if (offset + ext > length)
-        throw new RangeError("Trying to access beyond buffer length");
-    }
-    Buffer4.prototype.readUintLE = Buffer4.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let val = this[offset];
-      let mul = 1;
-      let i = 0;
-      while (++i < byteLength2 && (mul *= 256)) {
-        val += this[offset + i] * mul;
-      }
-      return val;
-    };
-    Buffer4.prototype.readUintBE = Buffer4.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        checkOffset(offset, byteLength2, this.length);
-      }
-      let val = this[offset + --byteLength2];
-      let mul = 1;
-      while (byteLength2 > 0 && (mul *= 256)) {
-        val += this[offset + --byteLength2] * mul;
-      }
-      return val;
-    };
-    Buffer4.prototype.readUint8 = Buffer4.prototype.readUInt8 = function readUInt8(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 1, this.length);
-      return this[offset];
-    };
-    Buffer4.prototype.readUint16LE = Buffer4.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      return this[offset] | this[offset + 1] << 8;
-    };
-    Buffer4.prototype.readUint16BE = Buffer4.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      return this[offset] << 8 | this[offset + 1];
-    };
-    Buffer4.prototype.readUint32LE = Buffer4.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
-    };
-    Buffer4.prototype.readUint32BE = Buffer4.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
-    };
-    Buffer4.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const lo = first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24;
-      const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
-      return BigInt(lo) + (BigInt(hi) << BigInt(32));
-    });
-    Buffer4.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
-      const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
-      return (BigInt(hi) << BigInt(32)) + BigInt(lo);
-    });
-    Buffer4.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let val = this[offset];
-      let mul = 1;
-      let i = 0;
-      while (++i < byteLength2 && (mul *= 256)) {
-        val += this[offset + i] * mul;
-      }
-      mul *= 128;
-      if (val >= mul)
-        val -= Math.pow(2, 8 * byteLength2);
-      return val;
-    };
-    Buffer4.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let i = byteLength2;
-      let mul = 1;
-      let val = this[offset + --i];
-      while (i > 0 && (mul *= 256)) {
-        val += this[offset + --i] * mul;
-      }
-      mul *= 128;
-      if (val >= mul)
-        val -= Math.pow(2, 8 * byteLength2);
-      return val;
-    };
-    Buffer4.prototype.readInt8 = function readInt8(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 1, this.length);
-      if (!(this[offset] & 128))
-        return this[offset];
-      return (255 - this[offset] + 1) * -1;
-    };
-    Buffer4.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      const val = this[offset] | this[offset + 1] << 8;
-      return val & 32768 ? val | 4294901760 : val;
-    };
-    Buffer4.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      const val = this[offset + 1] | this[offset] << 8;
-      return val & 32768 ? val | 4294901760 : val;
-    };
-    Buffer4.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
-    };
-    Buffer4.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
-    };
-    Buffer4.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
-      return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
-    });
-    Buffer4.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const val = (first << 24) + // Overflow
-      this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
-      return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
-    });
-    Buffer4.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return ieee754.read(this, offset, true, 23, 4);
-    };
-    Buffer4.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return ieee754.read(this, offset, false, 23, 4);
-    };
-    Buffer4.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 8, this.length);
-      return ieee754.read(this, offset, true, 52, 8);
-    };
-    Buffer4.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 8, this.length);
-      return ieee754.read(this, offset, false, 52, 8);
-    };
-    function checkInt(buf, value, offset, ext, max, min) {
-      if (!Buffer4.isBuffer(buf))
-        throw new TypeError('"buffer" argument must be a Buffer instance');
-      if (value > max || value < min)
-        throw new RangeError('"value" argument is out of bounds');
-      if (offset + ext > buf.length)
-        throw new RangeError("Index out of range");
-    }
-    Buffer4.prototype.writeUintLE = Buffer4.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
-        checkInt(this, value, offset, byteLength2, maxBytes, 0);
-      }
-      let mul = 1;
-      let i = 0;
-      this[offset] = value & 255;
-      while (++i < byteLength2 && (mul *= 256)) {
-        this[offset + i] = value / mul & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer4.prototype.writeUintBE = Buffer4.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
-        checkInt(this, value, offset, byteLength2, maxBytes, 0);
-      }
-      let i = byteLength2 - 1;
-      let mul = 1;
-      this[offset + i] = value & 255;
-      while (--i >= 0 && (mul *= 256)) {
-        this[offset + i] = value / mul & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer4.prototype.writeUint8 = Buffer4.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 1, 255, 0);
-      this[offset] = value & 255;
-      return offset + 1;
-    };
-    Buffer4.prototype.writeUint16LE = Buffer4.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 65535, 0);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      return offset + 2;
-    };
-    Buffer4.prototype.writeUint16BE = Buffer4.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 65535, 0);
-      this[offset] = value >>> 8;
-      this[offset + 1] = value & 255;
-      return offset + 2;
-    };
-    Buffer4.prototype.writeUint32LE = Buffer4.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 4294967295, 0);
-      this[offset + 3] = value >>> 24;
-      this[offset + 2] = value >>> 16;
-      this[offset + 1] = value >>> 8;
-      this[offset] = value & 255;
-      return offset + 4;
-    };
-    Buffer4.prototype.writeUint32BE = Buffer4.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 4294967295, 0);
-      this[offset] = value >>> 24;
-      this[offset + 1] = value >>> 16;
-      this[offset + 2] = value >>> 8;
-      this[offset + 3] = value & 255;
-      return offset + 4;
-    };
-    function wrtBigUInt64LE(buf, value, offset, min, max) {
-      checkIntBI(value, min, max, buf, offset, 7);
-      let lo = Number(value & BigInt(4294967295));
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      return offset;
-    }
-    function wrtBigUInt64BE(buf, value, offset, min, max) {
-      checkIntBI(value, min, max, buf, offset, 7);
-      let lo = Number(value & BigInt(4294967295));
-      buf[offset + 7] = lo;
-      lo = lo >> 8;
-      buf[offset + 6] = lo;
-      lo = lo >> 8;
-      buf[offset + 5] = lo;
-      lo = lo >> 8;
-      buf[offset + 4] = lo;
-      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
-      buf[offset + 3] = hi;
-      hi = hi >> 8;
-      buf[offset + 2] = hi;
-      hi = hi >> 8;
-      buf[offset + 1] = hi;
-      hi = hi >> 8;
-      buf[offset] = hi;
-      return offset + 8;
-    }
-    Buffer4.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
-      return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
-    });
-    Buffer4.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
-      return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
-    });
-    Buffer4.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        const limit = Math.pow(2, 8 * byteLength2 - 1);
-        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
-      }
-      let i = 0;
-      let mul = 1;
-      let sub = 0;
-      this[offset] = value & 255;
-      while (++i < byteLength2 && (mul *= 256)) {
-        if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
-          sub = 1;
-        }
-        this[offset + i] = (value / mul >> 0) - sub & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer4.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        const limit = Math.pow(2, 8 * byteLength2 - 1);
-        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
-      }
-      let i = byteLength2 - 1;
-      let mul = 1;
-      let sub = 0;
-      this[offset + i] = value & 255;
-      while (--i >= 0 && (mul *= 256)) {
-        if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
-          sub = 1;
-        }
-        this[offset + i] = (value / mul >> 0) - sub & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer4.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 1, 127, -128);
-      if (value < 0)
-        value = 255 + value + 1;
-      this[offset] = value & 255;
-      return offset + 1;
-    };
-    Buffer4.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 32767, -32768);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      return offset + 2;
-    };
-    Buffer4.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 32767, -32768);
-      this[offset] = value >>> 8;
-      this[offset + 1] = value & 255;
-      return offset + 2;
-    };
-    Buffer4.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 2147483647, -2147483648);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      this[offset + 2] = value >>> 16;
-      this[offset + 3] = value >>> 24;
-      return offset + 4;
-    };
-    Buffer4.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 2147483647, -2147483648);
-      if (value < 0)
-        value = 4294967295 + value + 1;
-      this[offset] = value >>> 24;
-      this[offset + 1] = value >>> 16;
-      this[offset + 2] = value >>> 8;
-      this[offset + 3] = value & 255;
-      return offset + 4;
-    };
-    Buffer4.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
-      return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
-    });
-    Buffer4.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
-      return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
-    });
-    function checkIEEE754(buf, value, offset, ext, max, min) {
-      if (offset + ext > buf.length)
-        throw new RangeError("Index out of range");
-      if (offset < 0)
-        throw new RangeError("Index out of range");
-    }
-    function writeFloat(buf, value, offset, littleEndian, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        checkIEEE754(buf, value, offset, 4, 34028234663852886e22, -34028234663852886e22);
-      }
-      ieee754.write(buf, value, offset, littleEndian, 23, 4);
-      return offset + 4;
-    }
-    Buffer4.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
-      return writeFloat(this, value, offset, true, noAssert);
-    };
-    Buffer4.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
-      return writeFloat(this, value, offset, false, noAssert);
-    };
-    function writeDouble(buf, value, offset, littleEndian, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        checkIEEE754(buf, value, offset, 8, 17976931348623157e292, -17976931348623157e292);
-      }
-      ieee754.write(buf, value, offset, littleEndian, 52, 8);
-      return offset + 8;
-    }
-    Buffer4.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
-      return writeDouble(this, value, offset, true, noAssert);
-    };
-    Buffer4.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
-      return writeDouble(this, value, offset, false, noAssert);
-    };
-    Buffer4.prototype.copy = function copy(target, targetStart, start, end) {
-      if (!Buffer4.isBuffer(target))
-        throw new TypeError("argument should be a Buffer");
-      if (!start)
-        start = 0;
-      if (!end && end !== 0)
-        end = this.length;
-      if (targetStart >= target.length)
-        targetStart = target.length;
-      if (!targetStart)
-        targetStart = 0;
-      if (end > 0 && end < start)
-        end = start;
-      if (end === start)
-        return 0;
-      if (target.length === 0 || this.length === 0)
-        return 0;
-      if (targetStart < 0) {
-        throw new RangeError("targetStart out of bounds");
-      }
-      if (start < 0 || start >= this.length)
-        throw new RangeError("Index out of range");
-      if (end < 0)
-        throw new RangeError("sourceEnd out of bounds");
-      if (end > this.length)
-        end = this.length;
-      if (target.length - targetStart < end - start) {
-        end = target.length - targetStart + start;
-      }
-      const len = end - start;
-      if (this === target && typeof Uint8Array.prototype.copyWithin === "function") {
-        this.copyWithin(targetStart, start, end);
-      } else {
-        Uint8Array.prototype.set.call(
-          target,
-          this.subarray(start, end),
-          targetStart
-        );
-      }
-      return len;
-    };
-    Buffer4.prototype.fill = function fill(val, start, end, encoding) {
-      if (typeof val === "string") {
-        if (typeof start === "string") {
-          encoding = start;
-          start = 0;
-          end = this.length;
-        } else if (typeof end === "string") {
-          encoding = end;
-          end = this.length;
-        }
-        if (encoding !== void 0 && typeof encoding !== "string") {
-          throw new TypeError("encoding must be a string");
-        }
-        if (typeof encoding === "string" && !Buffer4.isEncoding(encoding)) {
-          throw new TypeError("Unknown encoding: " + encoding);
-        }
-        if (val.length === 1) {
-          const code = val.charCodeAt(0);
-          if (encoding === "utf8" && code < 128 || encoding === "latin1") {
-            val = code;
-          }
-        }
-      } else if (typeof val === "number") {
-        val = val & 255;
-      } else if (typeof val === "boolean") {
-        val = Number(val);
-      }
-      if (start < 0 || this.length < start || this.length < end) {
-        throw new RangeError("Out of range index");
-      }
-      if (end <= start) {
-        return this;
-      }
-      start = start >>> 0;
-      end = end === void 0 ? this.length : end >>> 0;
-      if (!val)
-        val = 0;
-      let i;
-      if (typeof val === "number") {
-        for (i = start; i < end; ++i) {
-          this[i] = val;
-        }
-      } else {
-        const bytes = Buffer4.isBuffer(val) ? val : Buffer4.from(val, encoding);
-        const len = bytes.length;
-        if (len === 0) {
-          throw new TypeError('The value "' + val + '" is invalid for argument "value"');
-        }
-        for (i = 0; i < end - start; ++i) {
-          this[i + start] = bytes[i % len];
-        }
-      }
-      return this;
-    };
-    var errors = {};
-    function E(sym, getMessage, Base) {
-      errors[sym] = class NodeError extends Base {
-        constructor() {
-          super();
-          Object.defineProperty(this, "message", {
-            value: getMessage.apply(this, arguments),
-            writable: true,
-            configurable: true
-          });
-          this.name = `${this.name} [${sym}]`;
-          this.stack;
-          delete this.name;
-        }
-        get code() {
-          return sym;
-        }
-        set code(value) {
-          Object.defineProperty(this, "code", {
-            configurable: true,
-            enumerable: true,
-            value,
-            writable: true
-          });
-        }
-        toString() {
-          return `${this.name} [${sym}]: ${this.message}`;
-        }
-      };
-    }
-    E(
-      "ERR_BUFFER_OUT_OF_BOUNDS",
-      function(name) {
-        if (name) {
-          return `${name} is outside of buffer bounds`;
-        }
-        return "Attempt to access memory outside buffer bounds";
-      },
-      RangeError
-    );
-    E(
-      "ERR_INVALID_ARG_TYPE",
-      function(name, actual) {
-        return `The "${name}" argument must be of type number. Received type ${typeof actual}`;
-      },
-      TypeError
-    );
-    E(
-      "ERR_OUT_OF_RANGE",
-      function(str, range, input) {
-        let msg = `The value of "${str}" is out of range.`;
-        let received = input;
-        if (Number.isInteger(input) && Math.abs(input) > 2 ** 32) {
-          received = addNumericalSeparator(String(input));
-        } else if (typeof input === "bigint") {
-          received = String(input);
-          if (input > BigInt(2) ** BigInt(32) || input < -(BigInt(2) ** BigInt(32))) {
-            received = addNumericalSeparator(received);
-          }
-          received += "n";
-        }
-        msg += ` It must be ${range}. Received ${received}`;
-        return msg;
-      },
-      RangeError
-    );
-    function addNumericalSeparator(val) {
-      let res = "";
-      let i = val.length;
-      const start = val[0] === "-" ? 1 : 0;
-      for (; i >= start + 4; i -= 3) {
-        res = `_${val.slice(i - 3, i)}${res}`;
-      }
-      return `${val.slice(0, i)}${res}`;
-    }
-    function checkBounds(buf, offset, byteLength2) {
-      validateNumber(offset, "offset");
-      if (buf[offset] === void 0 || buf[offset + byteLength2] === void 0) {
-        boundsError(offset, buf.length - (byteLength2 + 1));
-      }
-    }
-    function checkIntBI(value, min, max, buf, offset, byteLength2) {
-      if (value > max || value < min) {
-        const n = typeof min === "bigint" ? "n" : "";
-        let range;
-        if (byteLength2 > 3) {
-          if (min === 0 || min === BigInt(0)) {
-            range = `>= 0${n} and < 2${n} ** ${(byteLength2 + 1) * 8}${n}`;
-          } else {
-            range = `>= -(2${n} ** ${(byteLength2 + 1) * 8 - 1}${n}) and < 2 ** ${(byteLength2 + 1) * 8 - 1}${n}`;
-          }
-        } else {
-          range = `>= ${min}${n} and <= ${max}${n}`;
-        }
-        throw new errors.ERR_OUT_OF_RANGE("value", range, value);
-      }
-      checkBounds(buf, offset, byteLength2);
-    }
-    function validateNumber(value, name) {
-      if (typeof value !== "number") {
-        throw new errors.ERR_INVALID_ARG_TYPE(name, "number", value);
-      }
-    }
-    function boundsError(value, length, type2) {
-      if (Math.floor(value) !== value) {
-        validateNumber(value, type2);
-        throw new errors.ERR_OUT_OF_RANGE(type2 || "offset", "an integer", value);
-      }
-      if (length < 0) {
-        throw new errors.ERR_BUFFER_OUT_OF_BOUNDS();
-      }
-      throw new errors.ERR_OUT_OF_RANGE(
-        type2 || "offset",
-        `>= ${type2 ? 1 : 0} and <= ${length}`,
-        value
-      );
-    }
-    var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
-    function base64clean(str) {
-      str = str.split("=")[0];
-      str = str.trim().replace(INVALID_BASE64_RE, "");
-      if (str.length < 2)
-        return "";
-      while (str.length % 4 !== 0) {
-        str = str + "=";
-      }
-      return str;
-    }
-    function utf8ToBytes(string, units) {
-      units = units || Infinity;
-      let codePoint;
-      const length = string.length;
-      let leadSurrogate = null;
-      const bytes = [];
-      for (let i = 0; i < length; ++i) {
-        codePoint = string.charCodeAt(i);
-        if (codePoint > 55295 && codePoint < 57344) {
-          if (!leadSurrogate) {
-            if (codePoint > 56319) {
-              if ((units -= 3) > -1)
-                bytes.push(239, 191, 189);
-              continue;
-            } else if (i + 1 === length) {
-              if ((units -= 3) > -1)
-                bytes.push(239, 191, 189);
-              continue;
-            }
-            leadSurrogate = codePoint;
-            continue;
-          }
-          if (codePoint < 56320) {
-            if ((units -= 3) > -1)
-              bytes.push(239, 191, 189);
-            leadSurrogate = codePoint;
-            continue;
-          }
-          codePoint = (leadSurrogate - 55296 << 10 | codePoint - 56320) + 65536;
-        } else if (leadSurrogate) {
-          if ((units -= 3) > -1)
-            bytes.push(239, 191, 189);
-        }
-        leadSurrogate = null;
-        if (codePoint < 128) {
-          if ((units -= 1) < 0)
-            break;
-          bytes.push(codePoint);
-        } else if (codePoint < 2048) {
-          if ((units -= 2) < 0)
-            break;
-          bytes.push(
-            codePoint >> 6 | 192,
-            codePoint & 63 | 128
-          );
-        } else if (codePoint < 65536) {
-          if ((units -= 3) < 0)
-            break;
-          bytes.push(
-            codePoint >> 12 | 224,
-            codePoint >> 6 & 63 | 128,
-            codePoint & 63 | 128
-          );
-        } else if (codePoint < 1114112) {
-          if ((units -= 4) < 0)
-            break;
-          bytes.push(
-            codePoint >> 18 | 240,
-            codePoint >> 12 & 63 | 128,
-            codePoint >> 6 & 63 | 128,
-            codePoint & 63 | 128
-          );
-        } else {
-          throw new Error("Invalid code point");
-        }
-      }
-      return bytes;
-    }
-    function asciiToBytes(str) {
-      const byteArray = [];
-      for (let i = 0; i < str.length; ++i) {
-        byteArray.push(str.charCodeAt(i) & 255);
-      }
-      return byteArray;
-    }
-    function utf16leToBytes(str, units) {
-      let c, hi, lo;
-      const byteArray = [];
-      for (let i = 0; i < str.length; ++i) {
-        if ((units -= 2) < 0)
-          break;
-        c = str.charCodeAt(i);
-        hi = c >> 8;
-        lo = c % 256;
-        byteArray.push(lo);
-        byteArray.push(hi);
-      }
-      return byteArray;
-    }
-    function base64ToBytes(str) {
-      return base64.toByteArray(base64clean(str));
-    }
-    function blitBuffer(src, dst, offset, length) {
-      let i;
-      for (i = 0; i < length; ++i) {
-        if (i + offset >= dst.length || i >= src.length)
-          break;
-        dst[i + offset] = src[i];
-      }
-      return i;
-    }
-    function isInstance(obj, type2) {
-      return obj instanceof type2 || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type2.name;
-    }
-    function numberIsNaN(obj) {
-      return obj !== obj;
-    }
-    var hexSliceLookupTable = function() {
-      const alphabet = "0123456789abcdef";
-      const table = new Array(256);
-      for (let i = 0; i < 16; ++i) {
-        const i16 = i * 16;
-        for (let j = 0; j < 16; ++j) {
-          table[i16 + j] = alphabet[i] + alphabet[j];
-        }
-      }
-      return table;
-    }();
-    function defineBigIntMethod(fn) {
-      return typeof BigInt === "undefined" ? BufferBigIntNotDefined : fn;
-    }
-    function BufferBigIntNotDefined() {
-      throw new Error("BigInt not supported");
-    }
-  }
-});
-
 // ../packages/cache/node_modules/buffer/index.js
-var require_buffer2 = __commonJS({
+var require_buffer = __commonJS({
   "../packages/cache/node_modules/buffer/index.js"(exports) {
     "use strict";
     var base64 = require_base64_js();
     var ieee754 = require_ieee754();
     var customInspectSymbol = typeof Symbol === "function" && typeof Symbol["for"] === "function" ? Symbol["for"]("nodejs.util.inspect.custom") : null;
-    exports.Buffer = Buffer4;
+    exports.Buffer = Buffer3;
     exports.SlowBuffer = SlowBuffer;
     exports.INSPECT_MAX_BYTES = 50;
     var K_MAX_LENGTH = 2147483647;
     exports.kMaxLength = K_MAX_LENGTH;
-    Buffer4.TYPED_ARRAY_SUPPORT = typedArraySupport();
-    if (!Buffer4.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
+    Buffer3.TYPED_ARRAY_SUPPORT = typedArraySupport();
+    if (!Buffer3.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
       console.error(
         "This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support."
       );
@@ -1943,18 +248,18 @@ var require_buffer2 = __commonJS({
         return false;
       }
     }
-    Object.defineProperty(Buffer4.prototype, "parent", {
+    Object.defineProperty(Buffer3.prototype, "parent", {
       enumerable: true,
       get: function() {
-        if (!Buffer4.isBuffer(this))
+        if (!Buffer3.isBuffer(this))
           return void 0;
         return this.buffer;
       }
     });
-    Object.defineProperty(Buffer4.prototype, "offset", {
+    Object.defineProperty(Buffer3.prototype, "offset", {
       enumerable: true,
       get: function() {
-        if (!Buffer4.isBuffer(this))
+        if (!Buffer3.isBuffer(this))
           return void 0;
         return this.byteOffset;
       }
@@ -1964,10 +269,10 @@ var require_buffer2 = __commonJS({
         throw new RangeError('The value "' + length + '" is invalid for option "size"');
       }
       const buf = new Uint8Array(length);
-      Object.setPrototypeOf(buf, Buffer4.prototype);
+      Object.setPrototypeOf(buf, Buffer3.prototype);
       return buf;
     }
-    function Buffer4(arg, encodingOrOffset, length) {
+    function Buffer3(arg, encodingOrOffset, length) {
       if (typeof arg === "number") {
         if (typeof encodingOrOffset === "string") {
           throw new TypeError(
@@ -1978,7 +283,7 @@ var require_buffer2 = __commonJS({
       }
       return from(arg, encodingOrOffset, length);
     }
-    Buffer4.poolSize = 8192;
+    Buffer3.poolSize = 8192;
     function from(value, encodingOrOffset, length) {
       if (typeof value === "string") {
         return fromString(value, encodingOrOffset);
@@ -2004,23 +309,23 @@ var require_buffer2 = __commonJS({
       }
       const valueOf = value.valueOf && value.valueOf();
       if (valueOf != null && valueOf !== value) {
-        return Buffer4.from(valueOf, encodingOrOffset, length);
+        return Buffer3.from(valueOf, encodingOrOffset, length);
       }
       const b2 = fromObject(value);
       if (b2)
         return b2;
       if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function") {
-        return Buffer4.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
+        return Buffer3.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
       }
       throw new TypeError(
         "The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value
       );
     }
-    Buffer4.from = function(value, encodingOrOffset, length) {
+    Buffer3.from = function(value, encodingOrOffset, length) {
       return from(value, encodingOrOffset, length);
     };
-    Object.setPrototypeOf(Buffer4.prototype, Uint8Array.prototype);
-    Object.setPrototypeOf(Buffer4, Uint8Array);
+    Object.setPrototypeOf(Buffer3.prototype, Uint8Array.prototype);
+    Object.setPrototypeOf(Buffer3, Uint8Array);
     function assertSize(size) {
       if (typeof size !== "number") {
         throw new TypeError('"size" argument must be of type number');
@@ -2038,24 +343,24 @@ var require_buffer2 = __commonJS({
       }
       return createBuffer(size);
     }
-    Buffer4.alloc = function(size, fill, encoding) {
+    Buffer3.alloc = function(size, fill, encoding) {
       return alloc(size, fill, encoding);
     };
     function allocUnsafe(size) {
       assertSize(size);
       return createBuffer(size < 0 ? 0 : checked(size) | 0);
     }
-    Buffer4.allocUnsafe = function(size) {
+    Buffer3.allocUnsafe = function(size) {
       return allocUnsafe(size);
     };
-    Buffer4.allocUnsafeSlow = function(size) {
+    Buffer3.allocUnsafeSlow = function(size) {
       return allocUnsafe(size);
     };
     function fromString(string, encoding) {
       if (typeof encoding !== "string" || encoding === "") {
         encoding = "utf8";
       }
-      if (!Buffer4.isEncoding(encoding)) {
+      if (!Buffer3.isEncoding(encoding)) {
         throw new TypeError("Unknown encoding: " + encoding);
       }
       const length = byteLength(string, encoding) | 0;
@@ -2096,11 +401,11 @@ var require_buffer2 = __commonJS({
       } else {
         buf = new Uint8Array(array, byteOffset, length);
       }
-      Object.setPrototypeOf(buf, Buffer4.prototype);
+      Object.setPrototypeOf(buf, Buffer3.prototype);
       return buf;
     }
     function fromObject(obj) {
-      if (Buffer4.isBuffer(obj)) {
+      if (Buffer3.isBuffer(obj)) {
         const len = checked(obj.length) | 0;
         const buf = createBuffer(len);
         if (buf.length === 0) {
@@ -2129,17 +434,17 @@ var require_buffer2 = __commonJS({
       if (+length != length) {
         length = 0;
       }
-      return Buffer4.alloc(+length);
+      return Buffer3.alloc(+length);
     }
-    Buffer4.isBuffer = function isBuffer(b2) {
-      return b2 != null && b2._isBuffer === true && b2 !== Buffer4.prototype;
+    Buffer3.isBuffer = function isBuffer(b2) {
+      return b2 != null && b2._isBuffer === true && b2 !== Buffer3.prototype;
     };
-    Buffer4.compare = function compare(a, b2) {
+    Buffer3.compare = function compare(a, b2) {
       if (isInstance(a, Uint8Array))
-        a = Buffer4.from(a, a.offset, a.byteLength);
+        a = Buffer3.from(a, a.offset, a.byteLength);
       if (isInstance(b2, Uint8Array))
-        b2 = Buffer4.from(b2, b2.offset, b2.byteLength);
-      if (!Buffer4.isBuffer(a) || !Buffer4.isBuffer(b2)) {
+        b2 = Buffer3.from(b2, b2.offset, b2.byteLength);
+      if (!Buffer3.isBuffer(a) || !Buffer3.isBuffer(b2)) {
         throw new TypeError(
           'The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array'
         );
@@ -2161,7 +466,7 @@ var require_buffer2 = __commonJS({
         return 1;
       return 0;
     };
-    Buffer4.isEncoding = function isEncoding(encoding) {
+    Buffer3.isEncoding = function isEncoding(encoding) {
       switch (String(encoding).toLowerCase()) {
         case "hex":
         case "utf8":
@@ -2179,12 +484,12 @@ var require_buffer2 = __commonJS({
           return false;
       }
     };
-    Buffer4.concat = function concat2(list, length) {
+    Buffer3.concat = function concat2(list, length) {
       if (!Array.isArray(list)) {
         throw new TypeError('"list" argument must be an Array of Buffers');
       }
       if (list.length === 0) {
-        return Buffer4.alloc(0);
+        return Buffer3.alloc(0);
       }
       let i;
       if (length === void 0) {
@@ -2193,14 +498,14 @@ var require_buffer2 = __commonJS({
           length += list[i].length;
         }
       }
-      const buffer = Buffer4.allocUnsafe(length);
+      const buffer = Buffer3.allocUnsafe(length);
       let pos = 0;
       for (i = 0; i < list.length; ++i) {
         let buf = list[i];
         if (isInstance(buf, Uint8Array)) {
           if (pos + buf.length > buffer.length) {
-            if (!Buffer4.isBuffer(buf))
-              buf = Buffer4.from(buf);
+            if (!Buffer3.isBuffer(buf))
+              buf = Buffer3.from(buf);
             buf.copy(buffer, pos);
           } else {
             Uint8Array.prototype.set.call(
@@ -2209,7 +514,7 @@ var require_buffer2 = __commonJS({
               pos
             );
           }
-        } else if (!Buffer4.isBuffer(buf)) {
+        } else if (!Buffer3.isBuffer(buf)) {
           throw new TypeError('"list" argument must be an Array of Buffers');
         } else {
           buf.copy(buffer, pos);
@@ -2219,7 +524,7 @@ var require_buffer2 = __commonJS({
       return buffer;
     };
     function byteLength(string, encoding) {
-      if (Buffer4.isBuffer(string)) {
+      if (Buffer3.isBuffer(string)) {
         return string.length;
       }
       if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
@@ -2262,7 +567,7 @@ var require_buffer2 = __commonJS({
         }
       }
     }
-    Buffer4.byteLength = byteLength;
+    Buffer3.byteLength = byteLength;
     function slowToString(encoding, start, end) {
       let loweredCase = false;
       if (start === void 0 || start < 0) {
@@ -2311,13 +616,13 @@ var require_buffer2 = __commonJS({
         }
       }
     }
-    Buffer4.prototype._isBuffer = true;
+    Buffer3.prototype._isBuffer = true;
     function swap(b2, n, m) {
       const i = b2[n];
       b2[n] = b2[m];
       b2[m] = i;
     }
-    Buffer4.prototype.swap16 = function swap16() {
+    Buffer3.prototype.swap16 = function swap16() {
       const len = this.length;
       if (len % 2 !== 0) {
         throw new RangeError("Buffer size must be a multiple of 16-bits");
@@ -2327,7 +632,7 @@ var require_buffer2 = __commonJS({
       }
       return this;
     };
-    Buffer4.prototype.swap32 = function swap32() {
+    Buffer3.prototype.swap32 = function swap32() {
       const len = this.length;
       if (len % 4 !== 0) {
         throw new RangeError("Buffer size must be a multiple of 32-bits");
@@ -2338,7 +643,7 @@ var require_buffer2 = __commonJS({
       }
       return this;
     };
-    Buffer4.prototype.swap64 = function swap64() {
+    Buffer3.prototype.swap64 = function swap64() {
       const len = this.length;
       if (len % 8 !== 0) {
         throw new RangeError("Buffer size must be a multiple of 64-bits");
@@ -2351,7 +656,7 @@ var require_buffer2 = __commonJS({
       }
       return this;
     };
-    Buffer4.prototype.toString = function toString2() {
+    Buffer3.prototype.toString = function toString2() {
       const length = this.length;
       if (length === 0)
         return "";
@@ -2359,15 +664,15 @@ var require_buffer2 = __commonJS({
         return utf8Slice(this, 0, length);
       return slowToString.apply(this, arguments);
     };
-    Buffer4.prototype.toLocaleString = Buffer4.prototype.toString;
-    Buffer4.prototype.equals = function equals(b2) {
-      if (!Buffer4.isBuffer(b2))
+    Buffer3.prototype.toLocaleString = Buffer3.prototype.toString;
+    Buffer3.prototype.equals = function equals(b2) {
+      if (!Buffer3.isBuffer(b2))
         throw new TypeError("Argument must be a Buffer");
       if (this === b2)
         return true;
-      return Buffer4.compare(this, b2) === 0;
+      return Buffer3.compare(this, b2) === 0;
     };
-    Buffer4.prototype.inspect = function inspect() {
+    Buffer3.prototype.inspect = function inspect() {
       let str = "";
       const max = exports.INSPECT_MAX_BYTES;
       str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim();
@@ -2376,13 +681,13 @@ var require_buffer2 = __commonJS({
       return "<Buffer " + str + ">";
     };
     if (customInspectSymbol) {
-      Buffer4.prototype[customInspectSymbol] = Buffer4.prototype.inspect;
+      Buffer3.prototype[customInspectSymbol] = Buffer3.prototype.inspect;
     }
-    Buffer4.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
+    Buffer3.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
       if (isInstance(target, Uint8Array)) {
-        target = Buffer4.from(target, target.offset, target.byteLength);
+        target = Buffer3.from(target, target.offset, target.byteLength);
       }
-      if (!Buffer4.isBuffer(target)) {
+      if (!Buffer3.isBuffer(target)) {
         throw new TypeError(
           'The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target
         );
@@ -2464,9 +769,9 @@ var require_buffer2 = __commonJS({
           return -1;
       }
       if (typeof val === "string") {
-        val = Buffer4.from(val, encoding);
+        val = Buffer3.from(val, encoding);
       }
-      if (Buffer4.isBuffer(val)) {
+      if (Buffer3.isBuffer(val)) {
         if (val.length === 0) {
           return -1;
         }
@@ -2539,13 +844,13 @@ var require_buffer2 = __commonJS({
       }
       return -1;
     }
-    Buffer4.prototype.includes = function includes(val, byteOffset, encoding) {
+    Buffer3.prototype.includes = function includes(val, byteOffset, encoding) {
       return this.indexOf(val, byteOffset, encoding) !== -1;
     };
-    Buffer4.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
+    Buffer3.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
       return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
     };
-    Buffer4.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
+    Buffer3.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
       return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
     };
     function hexWrite(buf, string, offset, length) {
@@ -2584,7 +889,7 @@ var require_buffer2 = __commonJS({
     function ucs2Write(buf, string, offset, length) {
       return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
     }
-    Buffer4.prototype.write = function write(string, offset, length, encoding) {
+    Buffer3.prototype.write = function write(string, offset, length, encoding) {
       if (offset === void 0) {
         encoding = "utf8";
         length = this.length;
@@ -2643,7 +948,7 @@ var require_buffer2 = __commonJS({
         }
       }
     };
-    Buffer4.prototype.toJSON = function toJSON2() {
+    Buffer3.prototype.toJSON = function toJSON2() {
       return {
         type: "Buffer",
         data: Array.prototype.slice.call(this._arr || this, 0)
@@ -2768,7 +1073,7 @@ var require_buffer2 = __commonJS({
       }
       return res;
     }
-    Buffer4.prototype.slice = function slice2(start, end) {
+    Buffer3.prototype.slice = function slice2(start, end) {
       const len = this.length;
       start = ~~start;
       end = end === void 0 ? len : ~~end;
@@ -2789,7 +1094,7 @@ var require_buffer2 = __commonJS({
       if (end < start)
         end = start;
       const newBuf = this.subarray(start, end);
-      Object.setPrototypeOf(newBuf, Buffer4.prototype);
+      Object.setPrototypeOf(newBuf, Buffer3.prototype);
       return newBuf;
     };
     function checkOffset(offset, ext, length) {
@@ -2798,7 +1103,7 @@ var require_buffer2 = __commonJS({
       if (offset + ext > length)
         throw new RangeError("Trying to access beyond buffer length");
     }
-    Buffer4.prototype.readUintLE = Buffer4.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
+    Buffer3.prototype.readUintLE = Buffer3.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
       offset = offset >>> 0;
       byteLength2 = byteLength2 >>> 0;
       if (!noAssert)
@@ -2811,7 +1116,7 @@ var require_buffer2 = __commonJS({
       }
       return val;
     };
-    Buffer4.prototype.readUintBE = Buffer4.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
+    Buffer3.prototype.readUintBE = Buffer3.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
       offset = offset >>> 0;
       byteLength2 = byteLength2 >>> 0;
       if (!noAssert) {
@@ -2824,37 +1129,37 @@ var require_buffer2 = __commonJS({
       }
       return val;
     };
-    Buffer4.prototype.readUint8 = Buffer4.prototype.readUInt8 = function readUInt8(offset, noAssert) {
+    Buffer3.prototype.readUint8 = Buffer3.prototype.readUInt8 = function readUInt8(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 1, this.length);
       return this[offset];
     };
-    Buffer4.prototype.readUint16LE = Buffer4.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
+    Buffer3.prototype.readUint16LE = Buffer3.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 2, this.length);
       return this[offset] | this[offset + 1] << 8;
     };
-    Buffer4.prototype.readUint16BE = Buffer4.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
+    Buffer3.prototype.readUint16BE = Buffer3.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 2, this.length);
       return this[offset] << 8 | this[offset + 1];
     };
-    Buffer4.prototype.readUint32LE = Buffer4.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
+    Buffer3.prototype.readUint32LE = Buffer3.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 4, this.length);
       return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
     };
-    Buffer4.prototype.readUint32BE = Buffer4.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
+    Buffer3.prototype.readUint32BE = Buffer3.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 4, this.length);
       return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
     };
-    Buffer4.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
+    Buffer3.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
       offset = offset >>> 0;
       validateNumber(offset, "offset");
       const first = this[offset];
@@ -2866,7 +1171,7 @@ var require_buffer2 = __commonJS({
       const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
       return BigInt(lo) + (BigInt(hi) << BigInt(32));
     });
-    Buffer4.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
+    Buffer3.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
       offset = offset >>> 0;
       validateNumber(offset, "offset");
       const first = this[offset];
@@ -2878,7 +1183,7 @@ var require_buffer2 = __commonJS({
       const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
       return (BigInt(hi) << BigInt(32)) + BigInt(lo);
     });
-    Buffer4.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
+    Buffer3.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
       offset = offset >>> 0;
       byteLength2 = byteLength2 >>> 0;
       if (!noAssert)
@@ -2894,7 +1199,7 @@ var require_buffer2 = __commonJS({
         val -= Math.pow(2, 8 * byteLength2);
       return val;
     };
-    Buffer4.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
+    Buffer3.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
       offset = offset >>> 0;
       byteLength2 = byteLength2 >>> 0;
       if (!noAssert)
@@ -2910,7 +1215,7 @@ var require_buffer2 = __commonJS({
         val -= Math.pow(2, 8 * byteLength2);
       return val;
     };
-    Buffer4.prototype.readInt8 = function readInt8(offset, noAssert) {
+    Buffer3.prototype.readInt8 = function readInt8(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 1, this.length);
@@ -2918,33 +1223,33 @@ var require_buffer2 = __commonJS({
         return this[offset];
       return (255 - this[offset] + 1) * -1;
     };
-    Buffer4.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
+    Buffer3.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 2, this.length);
       const val = this[offset] | this[offset + 1] << 8;
       return val & 32768 ? val | 4294901760 : val;
     };
-    Buffer4.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
+    Buffer3.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 2, this.length);
       const val = this[offset + 1] | this[offset] << 8;
       return val & 32768 ? val | 4294901760 : val;
     };
-    Buffer4.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
+    Buffer3.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 4, this.length);
       return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
     };
-    Buffer4.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
+    Buffer3.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 4, this.length);
       return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
     };
-    Buffer4.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
+    Buffer3.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
       offset = offset >>> 0;
       validateNumber(offset, "offset");
       const first = this[offset];
@@ -2955,7 +1260,7 @@ var require_buffer2 = __commonJS({
       const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
       return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
     });
-    Buffer4.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
+    Buffer3.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
       offset = offset >>> 0;
       validateNumber(offset, "offset");
       const first = this[offset];
@@ -2967,39 +1272,39 @@ var require_buffer2 = __commonJS({
       this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
       return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
     });
-    Buffer4.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
+    Buffer3.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 4, this.length);
       return ieee754.read(this, offset, true, 23, 4);
     };
-    Buffer4.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
+    Buffer3.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 4, this.length);
       return ieee754.read(this, offset, false, 23, 4);
     };
-    Buffer4.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
+    Buffer3.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 8, this.length);
       return ieee754.read(this, offset, true, 52, 8);
     };
-    Buffer4.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
+    Buffer3.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
       offset = offset >>> 0;
       if (!noAssert)
         checkOffset(offset, 8, this.length);
       return ieee754.read(this, offset, false, 52, 8);
     };
     function checkInt(buf, value, offset, ext, max, min) {
-      if (!Buffer4.isBuffer(buf))
+      if (!Buffer3.isBuffer(buf))
         throw new TypeError('"buffer" argument must be a Buffer instance');
       if (value > max || value < min)
         throw new RangeError('"value" argument is out of bounds');
       if (offset + ext > buf.length)
         throw new RangeError("Index out of range");
     }
-    Buffer4.prototype.writeUintLE = Buffer4.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
+    Buffer3.prototype.writeUintLE = Buffer3.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
       value = +value;
       offset = offset >>> 0;
       byteLength2 = byteLength2 >>> 0;
@@ -3015,7 +1320,7 @@ var require_buffer2 = __commonJS({
       }
       return offset + byteLength2;
     };
-    Buffer4.prototype.writeUintBE = Buffer4.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
+    Buffer3.prototype.writeUintBE = Buffer3.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
       value = +value;
       offset = offset >>> 0;
       byteLength2 = byteLength2 >>> 0;
@@ -3031,7 +1336,7 @@ var require_buffer2 = __commonJS({
       }
       return offset + byteLength2;
     };
-    Buffer4.prototype.writeUint8 = Buffer4.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
+    Buffer3.prototype.writeUint8 = Buffer3.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3039,7 +1344,7 @@ var require_buffer2 = __commonJS({
       this[offset] = value & 255;
       return offset + 1;
     };
-    Buffer4.prototype.writeUint16LE = Buffer4.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
+    Buffer3.prototype.writeUint16LE = Buffer3.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3048,7 +1353,7 @@ var require_buffer2 = __commonJS({
       this[offset + 1] = value >>> 8;
       return offset + 2;
     };
-    Buffer4.prototype.writeUint16BE = Buffer4.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
+    Buffer3.prototype.writeUint16BE = Buffer3.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3057,7 +1362,7 @@ var require_buffer2 = __commonJS({
       this[offset + 1] = value & 255;
       return offset + 2;
     };
-    Buffer4.prototype.writeUint32LE = Buffer4.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
+    Buffer3.prototype.writeUint32LE = Buffer3.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3068,7 +1373,7 @@ var require_buffer2 = __commonJS({
       this[offset] = value & 255;
       return offset + 4;
     };
-    Buffer4.prototype.writeUint32BE = Buffer4.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
+    Buffer3.prototype.writeUint32BE = Buffer3.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3119,13 +1424,13 @@ var require_buffer2 = __commonJS({
       buf[offset] = hi;
       return offset + 8;
     }
-    Buffer4.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
+    Buffer3.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
       return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
     });
-    Buffer4.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
+    Buffer3.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
       return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
     });
-    Buffer4.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
+    Buffer3.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert) {
@@ -3144,7 +1449,7 @@ var require_buffer2 = __commonJS({
       }
       return offset + byteLength2;
     };
-    Buffer4.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
+    Buffer3.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert) {
@@ -3163,7 +1468,7 @@ var require_buffer2 = __commonJS({
       }
       return offset + byteLength2;
     };
-    Buffer4.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
+    Buffer3.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3173,7 +1478,7 @@ var require_buffer2 = __commonJS({
       this[offset] = value & 255;
       return offset + 1;
     };
-    Buffer4.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
+    Buffer3.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3182,7 +1487,7 @@ var require_buffer2 = __commonJS({
       this[offset + 1] = value >>> 8;
       return offset + 2;
     };
-    Buffer4.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
+    Buffer3.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3191,7 +1496,7 @@ var require_buffer2 = __commonJS({
       this[offset + 1] = value & 255;
       return offset + 2;
     };
-    Buffer4.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
+    Buffer3.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3202,7 +1507,7 @@ var require_buffer2 = __commonJS({
       this[offset + 3] = value >>> 24;
       return offset + 4;
     };
-    Buffer4.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
+    Buffer3.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
       value = +value;
       offset = offset >>> 0;
       if (!noAssert)
@@ -3215,10 +1520,10 @@ var require_buffer2 = __commonJS({
       this[offset + 3] = value & 255;
       return offset + 4;
     };
-    Buffer4.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
+    Buffer3.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
       return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
     });
-    Buffer4.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
+    Buffer3.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
       return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
     });
     function checkIEEE754(buf, value, offset, ext, max, min) {
@@ -3236,10 +1541,10 @@ var require_buffer2 = __commonJS({
       ieee754.write(buf, value, offset, littleEndian, 23, 4);
       return offset + 4;
     }
-    Buffer4.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
+    Buffer3.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
       return writeFloat(this, value, offset, true, noAssert);
     };
-    Buffer4.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
+    Buffer3.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
       return writeFloat(this, value, offset, false, noAssert);
     };
     function writeDouble(buf, value, offset, littleEndian, noAssert) {
@@ -3251,14 +1556,14 @@ var require_buffer2 = __commonJS({
       ieee754.write(buf, value, offset, littleEndian, 52, 8);
       return offset + 8;
     }
-    Buffer4.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
+    Buffer3.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
       return writeDouble(this, value, offset, true, noAssert);
     };
-    Buffer4.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
+    Buffer3.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
       return writeDouble(this, value, offset, false, noAssert);
     };
-    Buffer4.prototype.copy = function copy(target, targetStart, start, end) {
-      if (!Buffer4.isBuffer(target))
+    Buffer3.prototype.copy = function copy(target, targetStart, start, end) {
+      if (!Buffer3.isBuffer(target))
         throw new TypeError("argument should be a Buffer");
       if (!start)
         start = 0;
@@ -3298,7 +1603,7 @@ var require_buffer2 = __commonJS({
       }
       return len;
     };
-    Buffer4.prototype.fill = function fill(val, start, end, encoding) {
+    Buffer3.prototype.fill = function fill(val, start, end, encoding) {
       if (typeof val === "string") {
         if (typeof start === "string") {
           encoding = start;
@@ -3311,7 +1616,7 @@ var require_buffer2 = __commonJS({
         if (encoding !== void 0 && typeof encoding !== "string") {
           throw new TypeError("encoding must be a string");
         }
-        if (typeof encoding === "string" && !Buffer4.isEncoding(encoding)) {
+        if (typeof encoding === "string" && !Buffer3.isEncoding(encoding)) {
           throw new TypeError("Unknown encoding: " + encoding);
         }
         if (val.length === 1) {
@@ -3341,7 +1646,7 @@ var require_buffer2 = __commonJS({
           this[i] = val;
         }
       } else {
-        const bytes = Buffer4.isBuffer(val) ? val : Buffer4.from(val, encoding);
+        const bytes = Buffer3.isBuffer(val) ? val : Buffer3.from(val, encoding);
         const len = bytes.length;
         if (len === 0) {
           throw new TypeError('The value "' + val + '" is invalid for argument "value"');
@@ -3664,7 +1969,7 @@ __export(router_exports, {
   createPath: () => createPath,
   createRouter: () => createRouter,
   createStaticHandler: () => createStaticHandler,
-  defer: () => defer,
+  defer: () => defer2,
   generatePath: () => generatePath,
   getStaticContextFromError: () => getStaticContextFromError,
   getToPathname: () => getToPathname,
@@ -3676,7 +1981,7 @@ __export(router_exports, {
   matchRoutes: () => matchRoutes,
   normalizePathname: () => normalizePathname,
   parsePath: () => parsePath,
-  redirect: () => redirect,
+  redirect: () => redirect2,
   redirectDocument: () => redirectDocument,
   resolvePath: () => resolvePath,
   resolveTo: () => resolveTo,
@@ -6736,7 +5041,7 @@ function getDoneFetcher(data) {
   };
   return fetcher;
 }
-var Action, PopStateEventType, ResultType, immutableRouteKeys, paramRe, dynamicSegmentValue, indexRouteValue, emptySegmentValue, staticSegmentValue, splatPenalty, isSplat, joinPaths, normalizePathname, normalizeSearch, normalizeHash, json2, AbortedDeferredError, DeferredData, defer, redirect, redirectDocument, ErrorResponseImpl, validMutationMethodsArr, validMutationMethods, validRequestMethodsArr, validRequestMethods, redirectStatusCodes, redirectPreserveMethodStatusCodes, IDLE_NAVIGATION, IDLE_FETCHER, IDLE_BLOCKER, ABSOLUTE_URL_REGEX, defaultMapRouteProperties, UNSAFE_DEFERRED_SYMBOL;
+var Action, PopStateEventType, ResultType, immutableRouteKeys, paramRe, dynamicSegmentValue, indexRouteValue, emptySegmentValue, staticSegmentValue, splatPenalty, isSplat, joinPaths, normalizePathname, normalizeSearch, normalizeHash, json2, AbortedDeferredError, DeferredData, defer2, redirect2, redirectDocument, ErrorResponseImpl, validMutationMethodsArr, validMutationMethods, validRequestMethodsArr, validRequestMethods, redirectStatusCodes, redirectPreserveMethodStatusCodes, IDLE_NAVIGATION, IDLE_FETCHER, IDLE_BLOCKER, ABSOLUTE_URL_REGEX, defaultMapRouteProperties, UNSAFE_DEFERRED_SYMBOL;
 var init_router = __esm({
   "../node_modules/@remix-run/router/dist/router.js"() {
     (function(Action2) {
@@ -6894,7 +5199,7 @@ var init_router = __esm({
         return Array.from(this.pendingKeysSet);
       }
     };
-    defer = function defer2(data, init) {
+    defer2 = function defer3(data, init) {
       if (init === void 0) {
         init = {};
       }
@@ -6903,7 +5208,7 @@ var init_router = __esm({
       } : init;
       return new DeferredData(data, responseInit);
     };
-    redirect = function redirect2(url, init) {
+    redirect2 = function redirect3(url, init) {
       if (init === void 0) {
         init = 302;
       }
@@ -6922,7 +5227,7 @@ var init_router = __esm({
       }));
     };
     redirectDocument = (url, init) => {
-      let response = redirect(url, init);
+      let response = redirect2(url, init);
       response.headers.set("X-Remix-Reload-Document", "true");
       return response;
     };
@@ -7179,10 +5484,10 @@ var k = Symbol();
 var w = Symbol();
 var f = Symbol();
 
-// node_modules/@remix-pwa/cache/dist/src/cache.js
+// ../packages/cache/dist/src/cache.js
 var B = __toESM(require_buffer(), 1);
 
-// node_modules/@remix-pwa/cache/dist/src/utils.js
+// ../packages/cache/dist/src/utils.js
 function mergeHeaders(...headers) {
   const merged = new Headers();
   for (const header of headers) {
@@ -7199,14 +5504,14 @@ function omit(key, obj) {
   return rest;
 }
 
-// node_modules/@remix-pwa/cache/dist/src/cache.js
+// ../packages/cache/dist/src/cache.js
 var Strategy;
-(function(Strategy3) {
-  Strategy3["CacheFirst"] = "cache-first";
-  Strategy3["NetworkFirst"] = "network-first";
-  Strategy3["CacheOnly"] = "cache-only";
-  Strategy3["NetworkOnly"] = "network-only";
-  Strategy3["StaleWhileRevalidate"] = "stale-while-revalidate";
+(function(Strategy2) {
+  Strategy2["CacheFirst"] = "cache-first";
+  Strategy2["NetworkFirst"] = "network-first";
+  Strategy2["CacheOnly"] = "cache-only";
+  Strategy2["NetworkOnly"] = "network-only";
+  Strategy2["StaleWhileRevalidate"] = "stale-while-revalidate";
 })(Strategy || (Strategy = {}));
 var RemixCache = class {
   /**
@@ -7448,7 +5753,7 @@ var RemixCache = class {
       await this._lruCleanup();
       return await cache.put(request, toBeCachedRes.clone());
     } catch (error) {
-      if (false)
+      if (true)
         console.error("Failed to put to cache:", error);
     }
   }
@@ -7471,7 +5776,7 @@ var RemixCache = class {
   }
 };
 
-// node_modules/@remix-pwa/cache/dist/src/storage.js
+// ../packages/cache/dist/src/storage.js
 var RemixCacheStorage = class {
   // eslint-disable-next-line no-useless-constructor
   constructor() {
@@ -7632,459 +5937,6 @@ var RemixCacheStorage = class {
 RemixCacheStorage._instances = /* @__PURE__ */ new Map();
 var Storage = RemixCacheStorage;
 
-// ../packages/cache/dist/src/cache.js
-var B2 = __toESM(require_buffer2(), 1);
-
-// ../packages/cache/dist/src/utils.js
-function mergeHeaders2(...headers) {
-  const merged = new Headers();
-  for (const header of headers) {
-    if (!header)
-      continue;
-    for (const [key, value] of new Headers(header).entries()) {
-      merged.set(key, value);
-    }
-  }
-  return merged;
-}
-function omit2(key, obj) {
-  const { [key]: omitted, ...rest } = obj;
-  return rest;
-}
-
-// ../packages/cache/dist/src/cache.js
-var Strategy2;
-(function(Strategy3) {
-  Strategy3["CacheFirst"] = "cache-first";
-  Strategy3["NetworkFirst"] = "network-first";
-  Strategy3["CacheOnly"] = "cache-only";
-  Strategy3["NetworkOnly"] = "network-only";
-  Strategy3["StaleWhileRevalidate"] = "stale-while-revalidate";
-})(Strategy2 || (Strategy2 = {}));
-var RemixCache2 = class {
-  /**
-   * Create a new `RemixCache` instance. Don't invoke this directly! Use `RemixCacheStorage.open()` instead.
-   * @constructor
-   * @param {object} options - Options for the RemixCache instance.
-   */
-  constructor(options) {
-    this._ttl = Infinity;
-    this._strategy = Strategy2.NetworkFirst;
-    this._maxItems = 100;
-    this.set = false;
-    this.name = options.name;
-    this._maxItems = options.maxItems || 100;
-    this._strategy = options.strategy || Strategy2.NetworkFirst;
-    this._ttl = options.ttl || Infinity;
-    if (this._strategy === Strategy2.NetworkOnly) {
-      this._ttl = -1;
-    }
-    if (options.maxItems || options.ttl || options.strategy) {
-      this.set = true;
-    } else {
-      this.set = false;
-    }
-  }
-  async _openCache() {
-    return await caches.open(`rp-${this.name}`);
-  }
-  async _getOrDeleteIfExpired(key, metadata) {
-    if (metadata.expiresAt === "Infinity") {
-      return false;
-    }
-    if (Number(metadata.expiresAt) <= Date.now()) {
-      return await this.delete(key);
-    }
-    return false;
-  }
-  async _lruCleanup() {
-    const isOverflowing = await this.length() >= this._maxItems;
-    if (isOverflowing) {
-      const cache = await this._openCache();
-      const keys2 = await cache.keys();
-      const values = await Promise.all(keys2.map((key) => cache.match(key)));
-      const keyVal = keys2.map((key, i) => ({ key, val: values[i] }));
-      const comparableArrayPromise = keyVal.map(async (val) => {
-        const { metadata } = await val.val.clone().json();
-        return {
-          metadata,
-          url: val.key.url
-        };
-      });
-      const comparableArray = await Promise.all(comparableArrayPromise);
-      const sortedArr = comparableArray.sort((a, b2) => {
-        return Number(a.metadata.accessedAt) - Number(b2.metadata.accessedAt);
-      });
-      const toBeDeletdItems = sortedArr.slice(0, sortedArr.length - this._maxItems + 1);
-      for (const deleted of toBeDeletdItems) {
-        await this.delete(deleted.url);
-      }
-    }
-  }
-  async _getResponseValue(request, response) {
-    const { metadata, value } = await response.clone().json();
-    const deleted = await this._getOrDeleteIfExpired(request, metadata);
-    const headers = new Headers(response.clone().headers);
-    if (!this.set) {
-      this.set = true;
-      this._ttl = metadata.cacheTtl;
-      this._maxItems = metadata.cacheMaxItems;
-      this._strategy = metadata.cacheStrategy;
-    }
-    const newHeader = new Headers(headers);
-    newHeader.set("X-Remix-PWA-TTL", metadata.expiresAt.toString());
-    newHeader.set("X-Remix-PWA-AccessTime", Date.now().toString());
-    newHeader.set("Content-Type", headers.get("X-Remix-PWA-Original-Content-Type") || "application/json");
-    const contentType = headers.get("X-Remix-PWA-Original-Content-Type") ?? "";
-    newHeader.delete("X-Remix-PWA-Original-Content-Type");
-    const responseOptions = {
-      status: response.status,
-      statusText: response.statusText,
-      headers: newHeader,
-      body: "null"
-    };
-    if (contentType.includes("application/json")) {
-      responseOptions.body = JSON.stringify(value);
-    } else if (contentType.includes("text")) {
-      responseOptions.body = value;
-    } else {
-      const buffer = B2.Buffer.from(value, "base64");
-      responseOptions.body = new Uint8Array(buffer);
-    }
-    if (!deleted) {
-      const res = new Response(responseOptions.body, omit2("body", responseOptions));
-      await this.put(request, res.clone(), void 0);
-      return res;
-    }
-    return void 0;
-  }
-  /**
-   * Delete an entry from the cache.
-   * Takes in the same parameters as `Cache.delete`.
-   * @param {RequestInfo | URL} request - The request to delete.
-   * @param {CacheQueryOptions} [options] - Options for the delete operation.
-   * @returns {Promise<boolean>} Returns `true` if an entry was deleted, otherwise `false`.
-   *
-   * @example
-   * ```js
-   * const cache = await initCache({ name: 'my-cache' });
-   *
-   * await cache.put('/hello-world', new Response('Hello World!'));
-   * await cache.delete('/hello-world');
-   * ```
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Cache/delete
-   */
-  async delete(request, options) {
-    return this._openCache().then((cache) => cache.delete(request, options));
-  }
-  /**
-   * Returns a Promise that resolves to the length of the Cache object.
-   *
-   * @returns {Promise<number>} The number of entries in the cache.
-   */
-  async length() {
-    const keys2 = await this.keys();
-    return keys2.length;
-  }
-  /**
-   * Returns a `Promise` that resolves to an array of Cache keys.
-   *
-   * @returns {Promise<readonly Request[]>} An array of Cache keys.
-   */
-  async keys() {
-    const cache = await this._openCache();
-    return await cache.keys();
-  }
-  /**
-   * Return a `Promise` that resolves to an entry in the cache object. Accepts the
-   * same parameters as `Cache.match`.
-   *
-   * @param {RequestInfo | URL} request - The request to match.
-   * @param {CacheQueryOptions} [options] - Options for the match operation.
-   *
-   * @returns {Promise<Response | undefined>} A `Promise` that resolves to the response, or `undefined` if not found.
-   */
-  async match(request, options) {
-    const cache = await this._openCache();
-    if (request instanceof URL || typeof request === "string") {
-      request = new Request(request);
-    }
-    const response = await cache.match(request.clone(), options);
-    if (!response) {
-      return void 0;
-    }
-    return await this._getResponseValue(request, response.clone());
-  }
-  /**
-   * Add an entry to the cache.
-   * Takes in the same parameters as `Cache.put`.
-   *
-   * @param {RequestInfo | URL} request - The request to add.
-   * @param {Response} response - The response to add.
-   * @param {number | undefined} ttl - The time-to-live of the cache entry in ms. Defaults to cache ttl.
-   * @returns {Promise<void>} A `Promise` that resolves when the entry is added to the cache.
-   *
-   * @example
-   * ```js
-   * const cache = await initCache({ name: 'my-cache' });
-   *
-   * await cache.put('/hello-world', new Response('Hello World!'));
-   * ```
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Cache/put
-   */
-  async put(request, response, ttl = void 0) {
-    const cache = await this._openCache();
-    if (request instanceof URL || typeof request === "string") {
-      request = new Request(request);
-    }
-    if (this._ttl <= 0 || ttl && ttl <= 0)
-      return;
-    if (response === null || response.status === 204 || response.statusText.toLowerCase() === "no content") {
-      await this.delete(request);
-      return;
-    }
-    const contentType = response.headers.get("Content-Type");
-    let data;
-    if (contentType && contentType.includes("application/json")) {
-      data = await response.clone().json();
-    } else if (contentType && contentType.includes("text")) {
-      data = await response.clone().text();
-    } else {
-      const buffer = await response.clone().arrayBuffer();
-      data = B2.Buffer.from(buffer).toString("base64");
-    }
-    if (!this.set) {
-      this.set = true;
-      const keys2 = await cache.keys();
-      const firstVal = await cache.match(keys2[0]);
-      if (firstVal) {
-        const { metadata } = await firstVal.clone().json();
-        this._ttl = metadata.cacheTtl;
-        this._maxItems = metadata.cacheMaxItems;
-        this._strategy = metadata.cacheStrategy;
-      } else {
-        this._ttl = Infinity;
-        this._maxItems = 100;
-        this._strategy = Strategy2.NetworkFirst;
-      }
-    }
-    const resHeaders = response.headers;
-    const expiresAt = resHeaders.get("X-Remix-PWA-TTL") || Date.now() + (ttl ?? this._ttl);
-    const accessedAt = resHeaders.get("X-Remix-PWA-AccessTime") || Date.now().toString();
-    const newHeaders = new Headers();
-    newHeaders.set("Content-Type", "application/json");
-    newHeaders.set("X-Remix-PWA-AccessTime", accessedAt);
-    newHeaders.set("X-Remix-PWA-Original-Content-Type", contentType || "text/plain");
-    newHeaders.set("X-Remix-PWA-TTL", expiresAt.toString());
-    const toBeCachedRes = new Response(JSON.stringify({
-      metadata: {
-        accessedAt,
-        // JSON can't store `Infinity`, so we store it as a string
-        expiresAt: expiresAt.toString(),
-        cacheTtl: this._ttl.toString(),
-        cacheMaxItems: this._maxItems,
-        cacheStrategy: this._strategy
-      },
-      value: data
-    }), {
-      status: response.status,
-      statusText: response.statusText,
-      headers: mergeHeaders2(resHeaders, newHeaders)
-    });
-    Object.defineProperty(toBeCachedRes, "url", { value: response.url });
-    Object.defineProperty(toBeCachedRes, "type", { value: response.type });
-    Object.defineProperty(toBeCachedRes, "ok", { value: response.ok });
-    Object.defineProperty(toBeCachedRes, "redirected", { value: response.redirected });
-    try {
-      await this._lruCleanup();
-      return await cache.put(request, toBeCachedRes.clone());
-    } catch (error) {
-      if (false)
-        console.error("Failed to put to cache:", error);
-    }
-  }
-  async add(request) {
-    return (
-      /* await - should this be awaited? */
-      fetch(request).then((res) => {
-        if (!res.ok) {
-          throw new Error("Failed to fetch");
-        }
-        return this.put(request, res.clone());
-      })
-    );
-  }
-  get ttl() {
-    return this._ttl;
-  }
-  get strategy() {
-    return this._strategy;
-  }
-};
-
-// ../packages/cache/dist/src/storage.js
-var RemixCacheStorage2 = class {
-  // eslint-disable-next-line no-useless-constructor
-  constructor() {
-  }
-  /**
-   * Initialize the Remix PWA Cache Storage. This will create a special cache for each
-   * existing cache in the browser or create a new map if none exist.
-   *
-   * Use in your service worker installation script. Make sure to call this before
-   * initializing any `RemixCache` instance.
-   *
-   * @example
-   * ```js
-   * import { RemixCacheStorage } from '@remix-run/cache';
-   *
-   * self.addEventListener('install', (event) => {
-   *  event.waitUntil(Promise.all[
-   *   RemixCacheStorage.init(),
-   *   // other stuff
-   *  ]);
-   * });
-   * ```
-   */
-  // static async init() {
-  //   if (typeof caches === 'undefined') {
-  //     throw new Error('Cache API is not available in this environment.');
-  //   }
-  //   if (this._instances.size > 0) {
-  //     return;
-  //   }
-  //   const cachesNames = await caches.keys();
-  //   for (const name of cachesNames) {
-  //     if (name.startsWith('rp-')) {
-  //       this._instances.set(name, new RemixCache({ name }));
-  //     }
-  //   }
-  // }
-  /**
-   * Create a custom cache that you can use across your application.
-   * Use this instead of initialising `RemixCache` directly.
-   */
-  static createCache(opts) {
-    const { name } = opts;
-    if (this._instances.has(name)) {
-      return this._instances.get(name);
-    }
-    const newCache = new RemixCache2(opts);
-    this._instances.set(`${name}`, newCache);
-    caches.open(`rp-${name}`);
-    return newCache;
-  }
-  /**
-   * Check wether a cache with the given name exists.
-   *
-   * @param name
-   */
-  static has(name) {
-    return this._instances.has(name);
-  }
-  static async _get(name) {
-    const cache = this._instances.get(name);
-    if (!cache && await caches.has(`rp-${name}`)) {
-      this._instances.set(name, new RemixCache2({ name }));
-      await this._instances.get(name)?.keys().then((keys2) => {
-        if (keys2.length > 0) {
-          caches.match(keys2[0]);
-        }
-      });
-    }
-    return this._instances.get(name);
-  }
-  /**
-   * Get a cache by name. Returns `undefined` if no cache with the given name exists.
-   * Use `has` to check if a cache exists. Or `open` to create one automatically if non exists.
-   *
-   * @param name
-   * @returns {RemixCache | undefined}
-   *
-   * @example
-   * ```js
-   * import { Storage } from '@remix-run/cache';
-   *
-   * const cache = Storage.get('my-cache');
-   * ```
-   */
-  static async get(name) {
-    return await this._get(name);
-  }
-  /**
-   * Get a cache by name. If no cache with the given name exists, create one.
-   *
-   * @param name Name of the cache - **must be unique**
-   * @param opts Options to pass to the `RemixCache` constructor if the cache is getting created
-   * @returns {RemixCache}
-   *
-   * @example
-   * ```js
-   * import { Storage } from '@remix-run/cache';
-   *
-   * const cache = Storage.open('my-cache');
-   * ```
-   */
-  static open(name, opts) {
-    const cache = this._instances.get(name);
-    if (!cache) {
-      return this.createCache({ name, ...opts });
-    }
-    return cache;
-  }
-  /**
-   * Delete a cache by name.
-   *
-   * @param name
-   */
-  static delete(name) {
-    const cache = this._instances.get(name);
-    if (cache) {
-      caches.delete(`rp-${name}`);
-      this._instances.delete(name);
-    }
-  }
-  /**
-   * Delete all caches.
-   */
-  static clear() {
-    caches.keys().then((keys2) => keys2.forEach((key) => key.startsWith("rp-") ? caches.delete(key) : null));
-    this._instances = /* @__PURE__ */ new Map();
-  }
-  /**
-   * Get all caches. **Don't use this except you know what you are doing!**
-   *
-   * Which, frankly speaking, you probably don't. So shoo away!
-   */
-  static get instances() {
-    return this._instances;
-  }
-  /**
-   * Get the number of caches.
-   *
-   * Return the length of the `RemixCacheStorage` store.
-   */
-  static get _length() {
-    return this._instances.size;
-  }
-  /**
-   * Check if a request is stored as the key of a response in all caches.
-   *
-   * Experimental. Use at your own risk!
-   *
-   * @param {RequestInfo | URL} request The request to check.
-   * @param {CacheQueryOptions} [options] Options to pass to the `Cache.match` method.
-   * @returns {Promise<Response | undefined>} A promise that resolves to the response if found, otherwise `undefined`.
-   */
-  static _match(request, options) {
-    return caches.match(request, options);
-  }
-};
-RemixCacheStorage2._instances = /* @__PURE__ */ new Map();
-var Storage2 = RemixCacheStorage2;
-
 // ../packages/strategy/dist/src/utils.js
 var isHttpRequest = (request) => {
   if (request instanceof Request) {
@@ -8107,7 +5959,7 @@ var cacheFirst = ({ cache: cacheName, cacheOptions, cacheQueryOptions, fetchDidF
     }
     let remixCache;
     if (typeof cacheName === "string") {
-      remixCache = Storage2.open(cacheName, cacheOptions);
+      remixCache = Storage.open(cacheName, cacheOptions);
     } else {
       remixCache = cacheName;
     }
@@ -8136,7 +5988,7 @@ var cacheOnly = ({ cache: cacheName, cacheOptions, cacheQueryOptions }) => {
     }
     let remixCache;
     if (typeof cacheName === "string") {
-      remixCache = Storage2.open(cacheName, cacheOptions);
+      remixCache = Storage.open(cacheName, cacheOptions);
     } else {
       remixCache = cacheName;
     }
@@ -8163,7 +6015,7 @@ var networkFirst = ({ cache: cacheName, cacheOptions, cacheQueryOptions, fetchDi
     }
     let remixCache;
     if (typeof cacheName === "string") {
-      remixCache = Storage2.open(cacheName, cacheOptions);
+      remixCache = Storage.open(cacheName, cacheOptions);
     } else {
       remixCache = cacheName;
     }
@@ -8205,7 +6057,7 @@ var staleWhileRevalidate = ({ cache: cacheName, cacheOptions, cacheQueryOptions,
     }
     let remixCache;
     if (typeof cacheName === "string") {
-      remixCache = Storage2.open(cacheName, cacheOptions);
+      remixCache = Storage.open(cacheName, cacheOptions);
     } else {
       remixCache = cacheName;
     }
@@ -8235,7 +6087,7 @@ var staleWhileRevalidate = ({ cache: cacheName, cacheOptions, cacheQueryOptions,
   };
 };
 
-// ../packages/sw/dist/src/private/logger.js
+// node_modules/@remix-pwa/sw/dist/src/private/logger.js
 var methodToColorMap = {
   debug: `#7f8c8d`,
   log: `#2ecc71`,
@@ -8246,13 +6098,12 @@ var methodToColorMap = {
   groupEnd: null
   // No colored prefix on groupEnd
 };
-var logger = true ? (() => {
+var logger = false ? (() => {
   const api = {};
   const loggerMethods = Object.keys(methodToColorMap);
   for (const key of loggerMethods) {
     const method = key;
-    api[method] = () => {
-    };
+    api[method] = noop;
   }
   return api;
 })() : (() => {
@@ -8306,7 +6157,7 @@ var logger = true ? (() => {
   return api;
 })();
 
-// ../packages/sw/dist/src/utils/worker.js
+// node_modules/@remix-pwa/sw/dist/src/utils/worker.js
 function isMethod(request, methods) {
   return methods.includes(request.method.toLowerCase());
 }
@@ -8327,7 +6178,7 @@ var matchRequest = (request, assetUrls = ["/build/", "/icons"]) => {
   }
 };
 
-// ../packages/sw/dist/src/message/message.js
+// node_modules/@remix-pwa/sw/dist/src/message/message.js
 var MessageHandler = class {
   /**
    * The plugins array is used to run plugins before and after the message handler.
@@ -8363,7 +6214,7 @@ var MessageHandler = class {
   }
 };
 
-// ../packages/sw/dist/src/message/remixNavigationHandler.js
+// node_modules/@remix-pwa/sw/dist/src/message/remixNavigationHandler.js
 var RemixNavigationHandler = class extends MessageHandler {
   dataCacheName;
   documentCacheName;
@@ -8386,17 +6237,16 @@ var RemixNavigationHandler = class extends MessageHandler {
       const { isMount, location: location2, manifest, matches } = data;
       const documentUrl = location2.pathname + location2.search + location2.hash;
       if (typeof dataCache2 === "string") {
-        dataCache2 = Storage2.open(dataCache2);
+        dataCache2 = Storage.open(dataCache2);
       }
       if (typeof documentCache2 === "string") {
-        documentCache2 = Storage2.open(documentCache2);
+        documentCache2 = Storage.open(documentCache2);
       }
-      const existingDocument = await Storage2._match(documentUrl);
+      const existingDocument = await Storage._match(documentUrl);
       if (!existingDocument || !isMount) {
         const response = await fetch(documentUrl);
         cachePromises.set(documentUrl, documentCache2.put(documentUrl, response).catch((error) => {
-          if (false)
-            logger.error(`Failed to cache document for ${documentUrl}:`, error);
+          logger.error(`Failed to cache document for ${documentUrl}:`, error);
         }));
       }
       if (isMount) {
@@ -8408,12 +6258,10 @@ var RemixNavigationHandler = class extends MessageHandler {
             search = search ? `?${search}` : "";
             const url = location2.pathname + search + location2.hash;
             if (!cachePromises.has(url)) {
-              if (false)
-                logger.debug("Caching data for:", url);
+              logger.debug("Caching data for:", url);
               const response = await fetch(url);
               cachePromises.set(url, dataCache2.put(url, response).catch((error) => {
-                if (false)
-                  logger.error(`Failed to cache data for ${url}:`, error);
+                logger.error(`Failed to cache data for ${url}:`, error);
               }));
             }
           }
@@ -9113,7 +6961,7 @@ var Queue = class {
         await this._queueStore.unshiftEntry(entry2);
         break;
     }
-    if (false) {
+    if (true) {
     }
     if (this._syncInProgress) {
       this._requestsAddedDuringSync = true;
@@ -9160,15 +7008,15 @@ var Queue = class {
     while (entry2 = await this.shiftRequest()) {
       try {
         await fetch(entry2.request.clone());
-        if (false) {
+        if (true) {
         }
       } catch (error) {
         await this.unshiftRequest(entry2);
-        if (false) {
+        if (true) {
         }
       }
     }
-    if (false) {
+    if (true) {
     }
   }
   /**
@@ -14133,66 +11981,18 @@ var workerLoader = async ({ context }) => {
   });
 };
 
-// routes-module:routes/_app.flights.tsx?worker
-var app_flights_exports = {};
-__export(app_flights_exports, {
-  workerAction: () => workerAction,
-  workerLoader: () => workerLoader2
-});
-
-// app/routes/_app.flights.tsx
-init_router();
-var import_react3 = __toESM(require_react());
-var import_react4 = __toESM(require_react2());
-var import_jsx_runtime2 = __toESM(require_jsx_runtime());
-var workerAction = async ({ request, context }) => {
-  const formData = await request.formData();
-  const { database, fetchFromServer } = context;
-  try {
-    fetchFromServer();
-    await database.selections.add(Object.fromEntries(formData.entries()));
-    return redirect("/selection");
-  } catch (error) {
-    throw json2({ message: "Something went wrong", error }, 500);
-  }
-};
-var workerLoader2 = async ({ context }) => {
-  try {
-    const { fetchFromServer, database } = context;
-    const [serverResult, clientResult] = await Promise.allSettled([
-      // NOTE: If the user decides to use the server loader, must use the `context.event.request` object instead of `request`.
-      // This is because we strip the `_data` and `index` from the request object just to follow what Remix does.
-      fetchFromServer().then((response) => response.json()).then(({ flights: flights2 }) => flights2),
-      database.flights.toArray()
-    ]);
-    const flights = serverResult.value || clientResult.value;
-    if (serverResult.value) {
-      await database.flights.bulkPut(
-        flights.map((f2) => ({
-          ...f2,
-          flightNumber: `${f2.flightNumber.split("-")[0].trim()} - client`
-        }))
-      );
-    }
-    return defer({ flights });
-  } catch (error) {
-    console.error(error);
-    throw json2({ message: "Something went wrong", error }, 500);
-  }
-};
-
 // routes-module:routes/basic-action.tsx?worker
 var basic_action_exports = {};
 __export(basic_action_exports, {
-  workerAction: () => workerAction2
+  workerAction: () => workerAction
 });
 
 // app/routes/basic-action.tsx
 var import_node2 = __toESM(require_node());
-var import_react5 = __toESM(require_react());
-var import_react6 = __toESM(require_react2());
-var import_jsx_runtime3 = __toESM(require_jsx_runtime());
-var workerAction2 = async ({ context }) => {
+var import_react3 = __toESM(require_react());
+var import_react4 = __toESM(require_react2());
+var import_jsx_runtime2 = __toESM(require_jsx_runtime());
+var workerAction = async ({ context }) => {
   const { fetchFromServer } = context;
   console.log("Worker action called");
   try {
@@ -14213,15 +12013,15 @@ var workerAction2 = async ({ context }) => {
 // routes-module:routes/basic-loader.tsx?worker
 var basic_loader_exports = {};
 __export(basic_loader_exports, {
-  workerLoader: () => workerLoader3
+  workerLoader: () => workerLoader2
 });
 
 // app/routes/basic-loader.tsx
 var import_node3 = __toESM(require_node());
-var import_react7 = __toESM(require_react());
-var import_react8 = __toESM(require_react2());
-var import_jsx_runtime4 = __toESM(require_jsx_runtime());
-var workerLoader3 = async ({ context }) => {
+var import_react5 = __toESM(require_react());
+var import_react6 = __toESM(require_react2());
+var import_jsx_runtime3 = __toESM(require_jsx_runtime());
+var workerLoader2 = async ({ context }) => {
   const { fetchFromServer } = context;
   const message = await Promise.race([
     fetchFromServer().then((response) => response.json()).then(({ message: message2 }) => message2),
@@ -14237,6 +12037,54 @@ var workerLoader3 = async ({ context }) => {
       }
     }
   );
+};
+
+// routes-module:routes/_app.flights.tsx?worker
+var app_flights_exports = {};
+__export(app_flights_exports, {
+  workerAction: () => workerAction2,
+  workerLoader: () => workerLoader3
+});
+
+// app/routes/_app.flights.tsx
+init_router();
+var import_react7 = __toESM(require_react());
+var import_react8 = __toESM(require_react2());
+var import_jsx_runtime4 = __toESM(require_jsx_runtime());
+var workerAction2 = async ({ request, context }) => {
+  const formData = await request.formData();
+  const { database, fetchFromServer } = context;
+  try {
+    fetchFromServer();
+    await database.selections.add(Object.fromEntries(formData.entries()));
+    return redirect2("/selection");
+  } catch (error) {
+    throw json2({ message: "Something went wrong", error }, 500);
+  }
+};
+var workerLoader3 = async ({ context }) => {
+  try {
+    const { fetchFromServer, database } = context;
+    const [serverResult, clientResult] = await Promise.allSettled([
+      // NOTE: If the user decides to use the server loader, must use the `context.event.request` object instead of `request`.
+      // This is because we strip the `_data` and `index` from the request object just to follow what Remix does.
+      fetchFromServer().then((response) => response.json()).then(({ flights: flights2 }) => flights2),
+      database.flights.toArray()
+    ]);
+    const flights = serverResult.value || clientResult.value;
+    if (serverResult.value) {
+      await database.flights.bulkPut(
+        flights.map((f2) => ({
+          ...f2,
+          flightNumber: `${f2.flightNumber.split("-")[0].trim()} - client`
+        }))
+      );
+    }
+    return defer2({ flights });
+  } catch (error) {
+    console.error(error);
+    throw json2({ message: "Something went wrong", error }, 500);
+  }
 };
 
 // routes-module:routes/strategies.tsx?worker
@@ -14351,7 +12199,7 @@ async function workerLoader5({ context }) {
 }
 
 // assets-module:@remix-pwa/dev?assets
-var assets = ["/build/root-7CK26VMZ.js", "/build/manifest-F72D7736.js", "/build/entry.client-WC46Q3Z2.js", "/build/__remix_entry_dev-HERBK3YF.js", "/build/routes/sync-away-FIS3FI5E.js", "/build/routes/strategies-KHN74V2Y.js", "/build/routes/selection-H5V7RQJ2.js", "/build/routes/basic-loader-AU6DX53L.js", "/build/routes/basic-caching-OOHMDI42.js", "/build/routes/basic-action-PXFBUJ6Z.js", "/build/routes/_index-RXPHYOQ6.js", "/build/routes/_app.flights-W7S6DTGH.js", "/build/routes/_app-CBP25HQZ.js", "/build/_shared/runtime-JC7ERE5X.js", "/build/_shared/remix_hmr-KOXB6O7Z.js", "/build/_shared/react-dom-SNQ2UIZM.js", "/build/_shared/react-XL6EHOTX.js", "/build/_shared/jsx-runtime-7KJOCM5J.js", "/build/_shared/jsx-dev-runtime-D5NCTVC4.js", "/build/_shared/esm-VCXQEZXN.js", "/build/_shared/client-LQHWDDYA.js", "/build/_shared/chunk-WBXWSE7J.js", "/build/_shared/chunk-TWSZTAQ6.js", "/build/_shared/chunk-TLBAXOHZ.js", "/build/_shared/chunk-STMUDJCL.js", "/build/_shared/chunk-PNG5AS42.js", "/build/_shared/chunk-NXSRMYPB.js", "/build/_shared/chunk-LOYKRDJM.js", "/build/_shared/chunk-G7CHZRZX.js", "/build/_shared/chunk-FXD4XYGV.js", "/build/_shared/chunk-3BVR7MZ6.js", "/build/_shared/chunk-2ZFQTCYB.js", "/build/_assets/tailwind-CWQG6AY7.css"];
+var assets = [];
 
 // entry-module:@remix-pwa/build/magic
 var routes = {
@@ -14371,14 +12219,6 @@ var routes = {
     caseSensitive: void 0,
     module: basic_caching_exports
   },
-  "routes/_app.flights": {
-    id: "routes/_app.flights",
-    parentId: "routes/_app",
-    path: "flights",
-    index: void 0,
-    caseSensitive: void 0,
-    module: app_flights_exports
-  },
   "routes/basic-action": {
     id: "routes/basic-action",
     parentId: "root",
@@ -14394,6 +12234,14 @@ var routes = {
     index: void 0,
     caseSensitive: void 0,
     module: basic_loader_exports
+  },
+  "routes/_app.flights": {
+    id: "routes/_app.flights",
+    parentId: "routes/_app",
+    path: "flights",
+    index: void 0,
+    caseSensitive: void 0,
+    module: app_flights_exports
   },
   "routes/strategies": {
     id: "routes/strategies",
@@ -14655,14 +12503,6 @@ _self.addEventListener(
 
 ieee754/index.js:
   (*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> *)
-
-buffer/index.js:
-  (*!
-   * The buffer module from node.js, for the browser.
-   *
-   * @author   Feross Aboukhadijeh <https://feross.org>
-   * @license  MIT
-   *)
 
 buffer/index.js:
   (*!

--- a/playground/remix.config.js
+++ b/playground/remix.config.js
@@ -2,12 +2,5 @@
 export default {
   ignoredRouteFiles: ['**/.*'],
   tailwind: true,
-  serverDependenciesToBundle: [
-    '@remix-pwa/sw',
-    '@remix-pwa/strategy',
-    '@remix-pwa/dev',
-    '@remix-pwa/sync',
-    '@remix-pwa/cache',
-    'idb',
-  ],
+  serverDependenciesToBundle: ['idb'],
 };

--- a/playground/remix.config.js
+++ b/playground/remix.config.js
@@ -1,7 +1,6 @@
 /** @type {import('@remix-pwa/dev').WorkerConfig} */
-module.exports = {
+export default {
   ignoredRouteFiles: ['**/.*'],
-  serverModuleFormat: 'cjs',
   tailwind: true,
   serverDependenciesToBundle: [
     '@remix-pwa/sw',


### PR DESCRIPTION
Fixes #112 

The packages were actually distributed correctly, the only actual problem was the `"buffer/"` import. There are ways around that, but I opted to replace that package with `uint8array-extras`, reasoning: https://sindresorhus.com/blog/goodbye-nodejs-buffer

Also:
- Updates the copy command in dev to use `cpy-cli` because `cp` doesn't work on windows
- Converts the playground to esm
- Replaces `ts-node` with `tsx` in the playground, since `ts-node` gave me an error, and it's also generally faster
