### PR TITLE
fix `buffer/` directory import

### DIFF
--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -1,4 +1,4 @@
-import * as B from 'buffer/';
+import * as B from 'buffer/index.js';
 
 import { mergeHeaders, omit } from './utils.js';
 


### PR DESCRIPTION
Aims to solve this issue (happening on a vanilla new project, Node 20):
<img width="1307" alt="image" src="https://github.com/remix-pwa/monorepo/assets/1588621/aadeb0ad-d072-444e-9fb1-cf64b2ab3971">
