### PR TITLE
fix(dev): Preserve source maps in transformations

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @remix-pwa/client 3.0.5 (2024-05-29)
+
+
+### Bug Fixes
+
+* **client:** added callback feature to installation prompt b17500a
+
 ## @remix-pwa/client 3.0.5-dev.1 (2024-05-29)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-pwa/client",
-  "version": "3.0.5-dev.1",
+  "version": "3.0.5",
   "description": "A set of utilities for client-side development to enhance the native feel of your Remix App",
   "repository": {
     "type": "git",

--- a/packages/dev/src/plugins/__test__/loader-plugin.test.ts
+++ b/packages/dev/src/plugins/__test__/loader-plugin.test.ts
@@ -71,7 +71,7 @@ describe('Remix PWA Vite Loader Plugin', () => {
 
       const transformed = plugin.transform(code, id);
 
-      expect(transformed).toBe(code);
+      expect(transformed).toBe(undefined);
     });
 
     test('should not transform target code when id does not match', () => {
@@ -80,7 +80,7 @@ describe('Remix PWA Vite Loader Plugin', () => {
 
       const transformed = plugin.transform(code, id);
 
-      expect(transformed).toBe(code);
+      expect(transformed).toBe(undefined);
     });
   });
 

--- a/packages/dev/src/plugins/__test__/virtual-sw-plugin.test.ts
+++ b/packages/dev/src/plugins/__test__/virtual-sw-plugin.test.ts
@@ -308,7 +308,9 @@ describe('Remix PWA Vite VirtualSW Plugin', () => {
          * This is a license comment
          */
         const a = 1;`;
-        expect((await plugin[0].transform(code)).trim()).toBe('const a = 1;');
+        const result = await plugin[0].transform(code);
+        expect(result.code.trim()).toBe('const a = 1;');
+        expect(result.map).toEqual({ mappings: '' });
 
         const code2 = `
 /**
@@ -316,7 +318,7 @@ describe('Remix PWA Vite VirtualSW Plugin', () => {
  * This is a license comment
  */
 const a = 1;`;
-        expect((await plugin[0].transform(code2)).trimStart()).toBe(`/**
+        expect((await plugin[0].transform(code2)).code.trimStart()).toBe(`/**
  * @license MIT
  * This is a license comment
  */

--- a/packages/dev/src/plugins/loader.ts
+++ b/packages/dev/src/plugins/loader.ts
@@ -39,8 +39,6 @@ export function LoaderPlugin(ctx: PWAPluginContext): Plugin {
             .join('\n')
             .trim()
         );
-      } else {
-        return code;
       }
     },
   };

--- a/packages/dev/src/plugins/virtual-sw.ts
+++ b/packages/dev/src/plugins/virtual-sw.ts
@@ -127,10 +127,14 @@ export function VirtualSWPlugins(ctx: PWAPluginContext): Plugin[] {
         const regex = /\/\*\*[\s\S]*?\*\//g;
 
         const licenseComments = code.match(regex)?.filter(predicate => /@license/.test(predicate)) ?? [];
-        return code.replaceAll(regex, match => {
+        code = code.replaceAll(regex, match => {
           if (licenseComments?.includes(match)) return match;
           return '';
         });
+        return {
+          code,
+          map: { mappings: '' },
+        };
       },
     },
     {


### PR DESCRIPTION
Rollup transformations should either generate source maps, return undefined if no transformation is necessary, or return an empty mappings object if mappings are not needed.

Should resolve: https://github.com/remix-pwa/monorepo/issues/167

See: https://rollupjs.org/plugin-development/#source-code-transformations