### PR TITLE
fix: stop useNetworkConnectivity from causing hydration errors.

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @remix-pwa/cli 1.2.5 (2024-08-11)
+
+
+### Bug Fixes
+
+* **cli:** added new `--dev` flag to the `upgrade` command - for updating to latest `dev` candidate d4f4414
+
 ## @remix-pwa/cli 1.2.5-dev.1 (2024-08-11)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-pwa/cli",
-  "version": "1.2.5-dev.1",
+  "version": "1.2.5",
   "description": "An elegant CLI for everything Remix PWA 💖",
   "repository": {
     "type": "git",

--- a/packages/dev/CHANGELOG.md
+++ b/packages/dev/CHANGELOG.md
@@ -1,3 +1,15 @@
+# @remix-pwa/dev 3.1.0 (2024-08-11)
+
+
+### Bug Fixes
+
+* **dev:** pre-rc-candidate: adding (minimal) global support for Remix SPA mode a035c49
+
+
+### Features
+
+* **dev:** added injectable vars cac1206
+
 # @remix-pwa/dev 3.1.0-dev.1 (2024-08-11)
 
 

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-pwa/dev",
-  "version": "3.1.0-dev.1",
+  "version": "3.1.0",
   "description": "An esbuild compiler for Service Workers in Remix.run",
   "repository": {
     "type": "git",

--- a/packages/sw/CHANGELOG.md
+++ b/packages/sw/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @remix-pwa/sw 3.0.9 (2024-08-11)
+
+
+### Bug Fixes
+
+* **sw:** added `matchOptions` for adding querying options to cache operations c87e507
+
 ## @remix-pwa/sw 3.0.9-dev.1 (2024-08-11)
 
 

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-pwa/sw",
-  "version": "3.0.9-dev.1",
+  "version": "3.0.9",
   "description": "Service Worker APIs and utilities for Remix PWA",
   "repository": {
     "type": "git",

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @remix-pwa/sync 3.0.4 (2024-08-11)
+
+
+
+
+
+### Dependencies
+
+* **@remix-pwa/sw:** upgraded to 3.0.9
+
 ## @remix-pwa/sync 3.0.4-dev.1 (2024-08-11)
 
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-pwa/sync",
-  "version": "3.0.4-dev.1",
+  "version": "3.0.4",
   "description": "A Background Sync addon for Remix PWA",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "rimraf": "^6.0.1"
   },
   "dependencies": {
-    "@remix-pwa/sw": "^3.0.9-dev.1",
+    "@remix-pwa/sw": "^3.0.9",
     "idb": "^8.0.0"
   }
 }

--- a/packages/worker-runtime/CHANGELOG.md
+++ b/packages/worker-runtime/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @remix-pwa/worker-runtime 2.1.4 (2024-08-11)
+
+
+### Bug Fixes
+
+* **worker-runtime:** added minimal support for runtimes in Remix SPA mode 6dd95e6
+
 ## @remix-pwa/worker-runtime 2.1.4-dev.1 (2024-08-11)
 
 

--- a/packages/worker-runtime/package.json
+++ b/packages/worker-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-pwa/worker-runtime",
-  "version": "2.1.4-dev.1",
+  "version": "2.1.4",
   "description": "A vanilla JavaScript worker runtime for Remix service workers",
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
**Description:**

We encountered hydration errors like:

```
Error: Hydration failed because the initial UI does not match what was rendered on the server.
```

**Solution:**

The issue was resolved by rewriting the hook to use `useSyncExternalStorage`, ensuring consistency between server and client rendering.

**Request for Review:**

The change has been tested and eliminates the hydration errors. Looking forward to your feedback and hoping for a quick merge.
