### PR TITLE
Add crossOrigin to ManifestLink to be able to fix CORS issues

### DIFF
--- a/packages/sw/src/components/ManifestLink.tsx
+++ b/packages/sw/src/components/ManifestLink.tsx
@@ -1,5 +1,12 @@
+import type { LinkHTMLAttributes } from 'react';
 import React from 'react';
 
-export const ManifestLink = ({ manifestUrl = '/manifest.webmanifest' }: { manifestUrl?: string }) => {
-  return <link rel="manifest" href={manifestUrl} />;
+export const ManifestLink = ({
+  crossOrigin,
+  manifestUrl = '/manifest.webmanifest',
+}: {
+  manifestUrl?: string;
+  crossOrigin?: LinkHTMLAttributes<HTMLLinkElement>['crossOrigin'];
+}) => {
+  return <link rel="manifest" href={manifestUrl} crossOrigin={crossOrigin} />;
 };


### PR DESCRIPTION
Hey, great repo. I easily added basic PWA features to my project, but faced one issue after deployment to Vercel, it looks like [this](https://stackoverflow.com/questions/69397440/chrome-gives-a-401-error-for-manifest-json) 
I made a workaround with the link tag in my project, but I just wanted to contribute to this library and fix the issue for others