### PR TITLE
Remix PWA Push Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1631,14 +1631,229 @@
       "deprecated": "Use @eslint/object-schema instead",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.0.tgz",
+      "integrity": "sha512-TNd+u1fAG8vf8YMgXzK2BI0u0xsphFv//T5rpF1eZ+8AAXby5Ll1qptr4/XVS45dvWDIzuBmmWIpVJRvnaNqzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/figures": "^1.0.7",
+        "@inquirer/type": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.0.tgz",
+      "integrity": "sha512-6QEzj6bZg8atviRIL+pR0tODC854cYSjvZxkyCarr8DVaOJPEyuGys7GmEG3W0Rb8kKSQec7P6okt0sJvNneFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.0.0.tgz",
+      "integrity": "sha512-7dwoKCGvgZGHWTZfOj2KLmbIAIdiXP9NTrwGaTO/XDfKMEmyBahZpnombiG6JDHmiOrmK3GLEJRXrWExXCDLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.7",
+        "@inquirer/type": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.0.0.tgz",
+      "integrity": "sha512-bhHAP7hIOxUjiTZrpjyAYD+2RFRa+PNutWeW7JdDPcWWG3GVRiFsu3pBGw9kN2PktoiilDWFGSR0dwXBzGQang==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/type": "^3.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.0.tgz",
+      "integrity": "sha512-mR7JHNIvCB4o12f75KN42he7s1O9tmcSN4wJ6l04oymfXKLn+lYJFI7z9lbe4/Ald6fm8nuF38fuY5hNPl3B+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/type": "^3.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.6.tgz",
-      "integrity": "sha512-yfZzps3Cso2UbM7WlxKwZQh2Hs6plrbjs1QnzQDZhK2DgyCo6D8AaHps9olkNcUFlcYERMqU3uJSp1gmy3s/qQ==",
-      "dev": true,
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz",
+      "integrity": "sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.0.tgz",
+      "integrity": "sha512-LD7MNzaX+q2OpU4Fn0i/SedhnnBCAnEzRr6L0MP6ohofFFlx9kp5EXX7flbRZlUnh8icOwC3NFmXTyP76hvo0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.0.tgz",
+      "integrity": "sha512-DUYfROyQNWm3q+JXL3S6s1/y/cOWRstnmt5zDXhdYNJ5N8TgCnHcDXKwW/dRZL7eBZupmDVHxdKCWZDUYUqmeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.0.tgz",
+      "integrity": "sha512-W4QRSzJDMKIvWSvQWOIhs6qba1MJ6yIoy+sazSFhl2QIwn58B0Yw3iZ/zLk3QqVcCsTmKcyrSNVWUJ5RVDLStw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/type": "^3.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.0.0.tgz",
+      "integrity": "sha512-y8kX/TmyBqV0H1i3cWbhiTljcuBtgVgyVXAVub3ba1j5/G+dxhYohK1JLRkaosPGKKf3LnEJsYK+GPabpfnaHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.0.0",
+        "@inquirer/confirm": "^5.0.0",
+        "@inquirer/editor": "^4.0.0",
+        "@inquirer/expand": "^4.0.0",
+        "@inquirer/input": "^4.0.0",
+        "@inquirer/number": "^3.0.0",
+        "@inquirer/password": "^4.0.0",
+        "@inquirer/rawlist": "^4.0.0",
+        "@inquirer/search": "^3.0.0",
+        "@inquirer/select": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.0.tgz",
+      "integrity": "sha512-frzJNoMsQBO1fxLXrtpxt2c8hUy/ASEmBpIOEnXY2CjylPnLsVyxrEq7hcOIqVJKHn1tIPfplfiSPowOTrrUDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/type": "^3.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.0.tgz",
+      "integrity": "sha512-AT9vkC2KD/PLHZZXIW5Tn/FnJzEU3xEZMLxNo9OggKoreDEKfTOKVM1LkYbDg6UQUOOjntXd0SsrvoHfCzS8cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/figures": "^1.0.7",
+        "@inquirer/type": "^3.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.0.tgz",
+      "integrity": "sha512-XTN4AIFusWbNCBU1Xm2YDxbtH94e/FOrC27U3QargSsoDT1mRm+aLfqE+oOZnUuxwtTnInRT8UHRU3MVOu52wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.0.0",
+        "@inquirer/figures": "^1.0.7",
+        "@inquirer/type": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.0.tgz",
+      "integrity": "sha512-YYykfbw/lefC7yKj7nanzQXILM7r3suIvyFlCcMskc99axmsSewXWkAfXKwMbgxL76iAFVmRwmYdwNZNc8gjog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4156,7 +4371,6 @@
       "version": "20.16.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
       "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -4838,7 +5052,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -5737,7 +5950,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/check-error": {
@@ -5898,7 +6110,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -8896,7 +9107,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
@@ -13747,7 +13957,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16639,7 +16848,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -17362,7 +17570,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -17505,7 +17712,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -18708,7 +18914,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -18774,7 +18979,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -18790,7 +18994,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -18803,7 +19006,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -18919,7 +19121,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
       "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -18967,16 +19168,17 @@
       "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^12.0.1",
-        "commander": "^12.0.0",
+        "@commander-js/extra-typings": "^12.1.0",
+        "@inquirer/prompts": "^7.0.0",
+        "commander": "^12.1.0",
         "pathe": "^1.1.2",
-        "picocolors": "^1.0.1",
-        "typescript": "^5.5.3"
+        "picocolors": "^1.1.0",
+        "typescript": "^5.6.2"
       },
       "devDependencies": {
         "@remix-pwa/eslint-config": "^0.0.0",
         "@remix-pwa/lint-staged-config": "^0.0.0",
-        "@remix-run/dev": "^2.10.3"
+        "@remix-run/dev": "^2.12.1"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/packages/push/server/index.ts
+++ b/packages/push/server/index.ts
@@ -1,4 +1,4 @@
-export { sendNotifications } from './notifications.js';
+export { getNotificationResults, sendNotifications, type NotificationResult } from './notifications.js';
 export { compareSubscriptionId, generateSubscriptionId } from './utils.js';
 
 export type { SubscriptionStorageProvider } from './storage.js';


### PR DESCRIPTION
Closes #271 

This push aims to make sending notifications more streamlined, allowing you to send notifications whilst retaining errors. As well as a new utility function for filtering results:

```ts
for (const subscription of allSubscriptions) {
 const result = await sendNotifications({ ... })

 // returns an object of the following:
 type Result = {
    success: boolean;
    subscription: PushSubscription;
    statusCode: number;
    error?: undefined;
 } | {
    success: boolean;
    subscription: PushSubscription;
    error: string;
    statusCode?: undefined;
 })[]

 // using the new `getNotificationResults` util on `result`, we get an object of the following
  {
    successful: results.filter((r): r is NotificationResult & { success: true } => r.success),
    failed: results.filter((r): r is NotificationResult & { success: false } => !r.success),
    summary: {
      total: number,
      successCount: number,
      failureCount: number,
    },
  }
}