### PR TITLE
Update ManifestLink.tsx

### DIFF
--- a/packages/sw/src/components/ManifestLink.tsx
+++ b/packages/sw/src/components/ManifestLink.tsx
@@ -8,5 +8,5 @@ export const ManifestLink = ({
   manifestUrl?: string;
   crossOrigin?: LinkHTMLAttributes<HTMLLinkElement>['crossOrigin'];
 }) => {
-  return <link rel="webmanifest" href={manifestUrl} crossOrigin={crossOrigin} />;
+  return <link rel="manifest" href={manifestUrl} crossOrigin={crossOrigin} />;
 };


### PR DESCRIPTION
### Change Description

Updated the `<link>` tag's `rel` attribute from `webmanifest` to `manifest`.

### Reason

According to the [W3C specification](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest), it is recommended to use `rel="manifest"` to specify a Web App Manifest file. Using the standardized value ensures better compatibility and maintainability.