### PR TITLE
Use "manifest" instead of "webmanifest" as link rel

### DIFF
--- a/packages/sw/src/components/ManifestLink.tsx
+++ b/packages/sw/src/components/ManifestLink.tsx
@@ -8,5 +8,5 @@ export const ManifestLink = ({
   manifestUrl?: string;
   crossOrigin?: LinkHTMLAttributes<HTMLLinkElement>['crossOrigin'];
 }) => {
-  return <link rel="webmanifest" href={manifestUrl} crossOrigin={crossOrigin} />;
+  return <link rel="manifest" href={manifestUrl} crossOrigin={crossOrigin} />;
 };


### PR DESCRIPTION
https://html.spec.whatwg.org/dev/links.html#link-type-manifest

"manifest" appears to be the supported relationship