### PR TITLE
fix(worker-runtime): remove deprecated `json` function from `@remix-run`

### DIFF
--- a/packages/worker-runtime/src/utils/response.ts
+++ b/packages/worker-runtime/src/utils/response.ts
@@ -1,18 +1,17 @@
 import type { ErrorResponse } from '@remix-run/router';
-import { json } from '@remix-run/server-runtime/dist/responses.js';
 
 /**
  * Converts an error response to a JSON response.
  */
 export function errorResponseToJson(errorResponse: ErrorResponse) {
   // @ts-expect-error
-  return json(errorResponse.error || { message: 'Unexpected Server Error' }, {
+  return errorResponse.error || { message: 'Unexpected Server Error' }, {
     status: errorResponse.status,
     statusText: errorResponse.statusText,
     headers: {
       'X-Remix-Error': 'yes',
     },
-  });
+  };
 }
 
 /**


### PR DESCRIPTION
Indeed this error used to give this message:
```
🏗️  Building Service Worker in production mode...
✗ Build failed in 491ms
Error during worker build: node_modules/@remix-pwa/worker-runtime/dist/src/utils/response.js (1:9): "json" is not exported by "__vite-optional-peer-dep:@remix-run/server-runtime/dist/responses.js:@remix-pwa/worker-runtime", imported by "node_modules/@remix-pwa/worker-runtime/dist/src/utils/response.js".
```
This is because `json` function was deprecated the migration to `remix-router-v7` and comes from the old package `@remix-run`

### Concern:
In the modified file, there is a check against `x-remix` headers and also a `X-Remix-Error` set in the response... is this okay, or is it a leftover?